### PR TITLE
docs: auditoria de conformidade do módulo Financeiro

### DIFF
--- a/Financeiro/documentacao_dre.md
+++ b/Financeiro/documentacao_dre.md
@@ -264,7 +264,7 @@ C - 2.1.3.02 - Provisão Férias a Pagar
 #### **Cadastro de Agrupamento DRE**
 
 **Tela de Configuração:**
-1. Acesse **Financeiro** → **Configurações** → **Agrupamentos DRE**
+1. Abra a pesquisa universal (F1), digite **Agrupamentos DRE** (código `[A CONFIRMAR]`) e abra a tela.
 2. Clique em **"Novo Agrupamento"**
 
 **Campos Obrigatórios:**
@@ -469,13 +469,13 @@ DESPESAS OPERACIONAIS
 ### 📋 1. Configuração Inicial
 
 #### **Passo 1.1: Estruturar Plano de Contas**
-1. Acesse **Financeiro** → **Cadastros** → **Plano de Contas**
+1. Abra a pesquisa universal (F1), digite **Plano de Contas** (código `[A CONFIRMAR]`) e abra a tela.
 2. Crie a **estrutura hierárquica** conforme sua necessidade
 3. Configure **Centros de Custo** obrigatórios quando necessário
 4. Defina **contas sintéticas** (totalizadoras) e **analíticas** (lançamentos)
 
 #### **Passo 1.2: Criar Agrupamentos DRE**
-1. Acesse **Financeiro** → **Configurações** → **Agrupamentos DRE**
+1. Abra a pesquisa universal (F1), digite **Agrupamentos DRE** (código `[A CONFIRMAR]`) e abra a tela.
 2. Crie os **agrupamentos principais**: Receitas, Custos, Despesas
 3. Defina **hierarquia** e **ordem de apresentação**
 4. Configure **fórmulas** para totalizações automáticas
@@ -495,7 +495,7 @@ DESPESAS OPERACIONAIS
 - **Folha RH**: Lançamentos automáticos da **Folha de Pagamento**
 
 #### **Passo 2.2: Lançamentos Manuais**
-1. Acesse **Financeiro** → **Lançamentos** → **Lançamentos Contábeis**
+1. Abra a pesquisa universal (F1), digite **Lançamentos Contábeis** (código `[A CONFIRMAR]`) e abra a tela.
 2. Informe **Data**, **Conta Débito**, **Conta Crédito** e **Valor**
 3. Preencha **Histórico** detalhado do lançamento
 4. Selecione **Centro de Custo** quando obrigatório
@@ -504,7 +504,7 @@ DESPESAS OPERACIONAIS
 ### 📈 3. Geração de Relatórios
 
 #### **Passo 3.1: DRE Básico**
-1. Acesse **Financeiro** → **Relatórios** → **DRE**
+1. Abra a pesquisa universal (F1), digite **DRE** (código `[A CONFIRMAR]`) e abra o relatório.
 2. Selecione **Período** (data inicial e final)
 3. Escolha **Empresa/Filial** (individual ou consolidado)
 4. Defina **Formato** (Gerencial ou Legal)
@@ -557,11 +557,11 @@ DESPESAS OPERACIONAIS
 - **Emissão de nota fiscal**: Gera lançamento automático de receita
 - **Impostos**: Lançados automaticamente em contas específicas
 - **Custo da mercadoria**: Baixado automaticamente do estoque
-- **Verificação**: Confira em **Financeiro** → **Consultas** → **Lançamentos por Período**
+- **Verificação**: Abra a pesquisa universal (F1), digite **Lançamentos por Período** (código `[A CONFIRMAR]`) e abra a consulta.
 
 #### **P: Como lançar despesas que não estão em outros módulos?**
 **R:**
-1. Acesse **Financeiro** → **Lançamentos** → **Lançamentos Contábeis**
+1. Abra a pesquisa universal (F1), digite **Lançamentos Contábeis** (código `[A CONFIRMAR]`) e abra a tela.
 2. Use template: **Débito** = Conta de Despesa, **Crédito** = Caixa/Banco
 3. **Exemplo**: Débito 6.1.01 (Energia Elétrica), Crédito 1.1.1.01 (Caixa)
 4. **Centro de custo**: Obrigatório quando configurado

--- a/Financeiro/documentacao_dre.md
+++ b/Financeiro/documentacao_dre.md
@@ -264,7 +264,7 @@ C - 2.1.3.02 - Provisão Férias a Pagar
 #### **Cadastro de Agrupamento DRE**
 
 **Tela de Configuração:**
-1. Abra a pesquisa universal (F1), digite **Agrupamentos DRE** (código `[A CONFIRMAR]`) e abra a tela.
+1. Abra a pesquisa universal (F1), digite **Agrupamento DRE** (código `130`) e abra a tela.
 2. Clique em **"Novo Agrupamento"**
 
 **Campos Obrigatórios:**
@@ -469,13 +469,13 @@ DESPESAS OPERACIONAIS
 ### 📋 1. Configuração Inicial
 
 #### **Passo 1.1: Estruturar Plano de Contas**
-1. Abra a pesquisa universal (F1), digite **Plano de Contas** (código `[A CONFIRMAR]`) e abra a tela.
+1. Abra a pesquisa universal (F1), digite **Plano de Contas** (código `14`) e abra a tela.
 2. Crie a **estrutura hierárquica** conforme sua necessidade
 3. Configure **Centros de Custo** obrigatórios quando necessário
 4. Defina **contas sintéticas** (totalizadoras) e **analíticas** (lançamentos)
 
 #### **Passo 1.2: Criar Agrupamentos DRE**
-1. Abra a pesquisa universal (F1), digite **Agrupamentos DRE** (código `[A CONFIRMAR]`) e abra a tela.
+1. Abra a pesquisa universal (F1), digite **Agrupamento DRE** (código `130`) e abra a tela.
 2. Crie os **agrupamentos principais**: Receitas, Custos, Despesas
 3. Defina **hierarquia** e **ordem de apresentação**
 4. Configure **fórmulas** para totalizações automáticas
@@ -495,7 +495,7 @@ DESPESAS OPERACIONAIS
 - **Folha RH**: Lançamentos automáticos da **Folha de Pagamento**
 
 #### **Passo 2.2: Lançamentos Manuais**
-1. Abra a pesquisa universal (F1), digite **Lançamentos Contábeis** (código `[A CONFIRMAR]`) e abra a tela.
+1. Abra a pesquisa universal (F1), digite **Lancamento RH** (código `84`) e abra a tela.
 2. Informe **Data**, **Conta Débito**, **Conta Crédito** e **Valor**
 3. Preencha **Histórico** detalhado do lançamento
 4. Selecione **Centro de Custo** quando obrigatório
@@ -504,7 +504,7 @@ DESPESAS OPERACIONAIS
 ### 📈 3. Geração de Relatórios
 
 #### **Passo 3.1: DRE Básico**
-1. Abra a pesquisa universal (F1), digite **DRE** (código `[A CONFIRMAR]`) e abra o relatório.
+1. Abra a pesquisa universal (F1), digite **Relatório DRE** (código `221`) e abra o relatório.
 2. Selecione **Período** (data inicial e final)
 3. Escolha **Empresa/Filial** (individual ou consolidado)
 4. Defina **Formato** (Gerencial ou Legal)
@@ -557,11 +557,11 @@ DESPESAS OPERACIONAIS
 - **Emissão de nota fiscal**: Gera lançamento automático de receita
 - **Impostos**: Lançados automaticamente em contas específicas
 - **Custo da mercadoria**: Baixado automaticamente do estoque
-- **Verificação**: Abra a pesquisa universal (F1), digite **Lançamentos por Período** (código `[A CONFIRMAR]`) e abra a consulta.
+- **Verificação**: Abra a pesquisa universal (F1), digite **Contas PR** (código `301`) e abra a consulta de lançamentos.
 
 #### **P: Como lançar despesas que não estão em outros módulos?**
 **R:**
-1. Abra a pesquisa universal (F1), digite **Lançamentos Contábeis** (código `[A CONFIRMAR]`) e abra a tela.
+1. Abra a pesquisa universal (F1), digite **Lancamento RH** (código `84`) e abra a tela.
 2. Use template: **Débito** = Conta de Despesa, **Crédito** = Caixa/Banco
 3. **Exemplo**: Débito 6.1.01 (Energia Elétrica), Crédito 1.1.1.01 (Caixa)
 4. **Centro de custo**: Obrigatório quando configurado

--- a/Financeiro/documentacao_portadores.md
+++ b/Financeiro/documentacao_portadores.md
@@ -24,7 +24,7 @@ O **Módulo Portadores** é um componente essencial do sistema Sol.NET ERP, resp
 
 ### Organização da Interface
 
-O módulo é organizado através do **Cadastro de Portadores**, que centraliza todas as configurações e funcionalidades relacionadas ao gerenciamento de instrumentos de pagamento. A interface possui duas visualizações principais:
+O módulo é organizado através do **Cadastro de Portadores** (código `[A CONFIRMAR]` na pesquisa F1), que centraliza todas as configurações e funcionalidades relacionadas ao gerenciamento de instrumentos de pagamento. A interface possui duas visualizações principais:
 
 - **Visualização de Consulta**: Lista todos os portadores cadastrados com informações resumidas
 - **Visualização de Cadastro**: Permite criação e edição detalhada de portadores através de abas especializadas
@@ -566,7 +566,7 @@ O sistema mantém automaticamente um log detalhado de todas as alterações real
 - Histórico de valores alterados
 
 **Acesso aos Logs:**
-- Menu Sistema → Logs → Auditoria
+- Abra a pesquisa universal (F1), digite **Auditoria** (código `[A CONFIRMAR]`) e abra a tela de logs.
 - Filtrar por "Portadores" para ver apenas mudanças em portadores
 - Consultar histórico específico por portador
 
@@ -657,7 +657,7 @@ O sistema mantém automaticamente um log detalhado de todas as alterações real
 
 Para dúvidas técnicas ou problemas específicos:
 
-1. **Consulte os logs**: Sistema → Logs → Portadores
+1. **Consulte os logs**: abra a pesquisa universal (F1) e digite **Auditoria** (código `[A CONFIRMAR]`); filtre por "Portadores".
 2. **Verifique configurações**: Duplo-clique no portador para editar
 3. **Teste isolado**: Use ambiente de homologação quando disponível  
 4. **Documente casos**: Contribua com novos cenários de uso

--- a/Financeiro/documentacao_portadores.md
+++ b/Financeiro/documentacao_portadores.md
@@ -24,7 +24,7 @@ O **Módulo Portadores** é um componente essencial do sistema Sol.NET ERP, resp
 
 ### Organização da Interface
 
-O módulo é organizado através do **Cadastro de Portadores** (código `[A CONFIRMAR]` na pesquisa F1), que centraliza todas as configurações e funcionalidades relacionadas ao gerenciamento de instrumentos de pagamento. A interface possui duas visualizações principais:
+O módulo é organizado através do **Cadastro de Portadores** (código `12` na pesquisa F1), que centraliza todas as configurações e funcionalidades relacionadas ao gerenciamento de instrumentos de pagamento. A interface possui duas visualizações principais:
 
 - **Visualização de Consulta**: Lista todos os portadores cadastrados com informações resumidas
 - **Visualização de Cadastro**: Permite criação e edição detalhada de portadores através de abas especializadas
@@ -557,19 +557,6 @@ O sistema mantém controle automático de:
 - Ajustar o valor da parcela para atender ao mínimo exigido
 - Ou ajustar a configuração do portador se o limite estiver inadequado
 
-### Logs e Auditoria
-
-O sistema mantém automaticamente um log detalhado de todas as alterações realizadas nos portadores, incluindo:
-- Data e hora de cada modificação
-- Usuário responsável pela alteração
-- Tipo de operação realizada (criação, edição, exclusão)
-- Histórico de valores alterados
-
-**Acesso aos Logs:**
-- Abra a pesquisa universal (F1), digite **Auditoria** (código `[A CONFIRMAR]`) e abra a tela de logs.
-- Filtrar por "Portadores" para ver apenas mudanças em portadores
-- Consultar histórico específico por portador
-
 ### Backup e Restore
 
 **Informações Incluídas no Backup:**
@@ -657,10 +644,9 @@ O sistema mantém automaticamente um log detalhado de todas as alterações real
 
 Para dúvidas técnicas ou problemas específicos:
 
-1. **Consulte os logs**: abra a pesquisa universal (F1) e digite **Auditoria** (código `[A CONFIRMAR]`); filtre por "Portadores".
-2. **Verifique configurações**: Duplo-clique no portador para editar
-3. **Teste isolado**: Use ambiente de homologação quando disponível  
-4. **Documente casos**: Contribua com novos cenários de uso
+1. **Verifique configurações**: Duplo-clique no portador para editar
+2. **Teste isolado**: Use ambiente de homologação quando disponível  
+3. **Documente casos**: Contribua com novos cenários de uso
 
 ---
 


### PR DESCRIPTION
## Resumo

Aplica o modo **Auditar** da skill `solnet-docs` no módulo `Financeiro/`. Foram auditados `README.md`, `documentacao_dre.md` e `documentacao_portadores.md` contra as regras do `CLAUDE.md`.

## Violações encontradas e correções aplicadas

| # | Arquivo | Violação | Correção |
|---|---------|----------|----------|
| 1 | `documentacao_dre.md` | Caminho de menu "Financeiro → Configurações → Agrupamentos DRE" (2 ocorrências) | Substituído por pesquisa F1 com **Agrupamento DRE** (código `130`) |
| 2 | `documentacao_dre.md` | Caminho de menu "Financeiro → Cadastros → Plano de Contas" | Substituído por pesquisa F1 com **Plano de Contas** (código `14`) |
| 3 | `documentacao_dre.md` | Caminho de menu "Financeiro → Lançamentos → Lançamentos Contábeis" (2 ocorrências) | Substituído por pesquisa F1 com **Lancamento RH** (código `84`) — esta é a tela real do sistema |
| 4 | `documentacao_dre.md` | Caminho de menu "Financeiro → Relatórios → DRE" | Substituído por pesquisa F1 com **Relatório DRE** (código `221`) |
| 5 | `documentacao_dre.md` | Caminho de menu "Financeiro → Consultas → Lançamentos por Período" | Substituído por pesquisa F1 com **Contas PR** (código `301`) — nome real da tela |
| 6 | `documentacao_portadores.md` | Primeira menção a "Cadastro de Portadores" sem código | Acrescentado código `12` |
| 7 | `documentacao_portadores.md` | Seção "Logs e Auditoria" + caminho "Menu Sistema → Logs → Auditoria" | Seção removida na íntegra (orientação do solicitante); referência correspondente em "Suporte" também removida |

## Códigos de tela referenciados

Todos confirmados pelo solicitante (sem validação automática contra `uProcessosAtualizacaoPrincipal.pas` — o PAT de leitura de `hetosoft/ProjetosSol.NET` retornou 401 nesta sessão):

- `130` — Agrupamento DRE
- `14` — Plano de Contas
- `84` — Lancamento RH
- `221` — Relatório DRE
- `301` — Contas PR
- `12` — Cadastro de Portadores

## Sem violação detectada

- Nomenclatura de arquivos em snake_case
- Sem `%20` em links internos
- Sem atalhos não validados (F2/F4/Ctrl+…); apenas F1 aparece, conforme regra
- Cabeçalho com emoji + `## 🎯 Visão Geral` + rodapé de metadados em todos os docs
- Sem jargão Delphi nem referências a código-fonte
- Sem instruções de alteração em `Cadastro de Empresas` ou `Cadastro de Tipos de Movimento` (única referência é descritiva, não instrutiva — nota de acesso restrito não se aplica)

## Observações fora do escopo formal de conformidade (não corrigidas)

- `documentacao_dre.md` menciona "versão Pro", "versão Enterprise", "Power BI/Tableau/QlikView", "App móvel", `0800-xxx-xxxx`, `[suporte.solnet.com.br](#)` — placeholders ou afirmações que podem não corresponder ao produto real.
- O módulo Financeiro **não possui** `guia_rapido.md` nem `faq.md` separados (o FAQ está embutido no `documentacao_dre.md`). Diverge do pattern de 4 documentos do `CLAUDE.md`, mas é decisão de escopo, não conformidade.

## Test plan

- [ ] Conferir visualmente as 7 substituições de acesso por tela no `documentacao_dre.md`
- [ ] Confirmar que a seção "Logs e Auditoria" foi removida do `documentacao_portadores.md` e nada quebrou no índice / sidebar
- [ ] Validar os 6 códigos de tela contra a release atual do Sol.NET (especialmente `221` — interpretado a partir de `22)1` informado em chat)