### PR TITLE
docs(movimentacao): reescrita parte 2 — trio Movimentos 201/202/203

### DIFF
--- a/Movimentacao/Movimentos/README.md
+++ b/Movimentacao/Movimentos/README.md
@@ -7,9 +7,9 @@ permalink: /Movimentacao/Movimentos/
 
 **Movimentos** é o coração operacional do módulo Movimentação: a tela onde toda transação de estoque com documento (compra recebida, venda emitida, transferência, devolução, ajuste, produção) é lançada, consultada, editada, finalizada, quitada e auditada. O Sol.NET expõe o mesmo formulário sob **três códigos** distintos na pesquisa universal, um por categoria:
 
-- [Movimentos de Compras](movimentos_de_compras.md) — código `201` — entrada de mercadoria com documento fiscal de compra.
-- [Movimentos de Vendas](movimentos_de_vendas.md) — código `202` — saída comercial pela retaguarda (balcão, pedido faturado, OS faturada). Vendas em frente de caixa acontecem na aplicação **PDV**, à parte, documentada em outra seção.
-- [Outros Movimentos](outros_movimentos.md) — código `203` — transferências, ajustes, perdas, produção, brindes, consumo interno.
+- [Movimentos de Compras](movimentos_de_compras.md) — código `201` — entrada com documento fiscal de compra (notas de fornecedor, devoluções para fornecedor, importações).
+- [Movimentos de Vendas](movimentos_de_vendas.md) — código `202` — Tipos acessados por **vendedores** (venda balcão, orçamento, pedido de venda, OS faturada). Vendas em frente de caixa acontecem na aplicação **PDV**, à parte, documentada em outra seção.
+- [Outros Movimentos](outros_movimentos.md) — código `203` — Tipos operados pela **retaguarda**: **transferências entre filiais**, **devoluções de venda**, ajustes, perdas, produção, brindes, consumo interno.
 
 Cada movimento amarra **um** [Tipo de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (cadastro `37`) e dele herda todas as regras: efeito no estoque (via `Transações de Estoque` — `33`), efeito no financeiro, fiscal (modelo, série, CFOPs), Funcionários exigidos, Tabela de Preço aplicada, Local de Estoque padrão, Portador, Condição de Pagamento padrão, regras de mobile/devolução/cashback.
 

--- a/Movimentacao/Movimentos/README.md
+++ b/Movimentacao/Movimentos/README.md
@@ -8,10 +8,10 @@ permalink: /Movimentacao/Movimentos/
 **Movimentos** é o coração operacional do módulo Movimentação: a tela onde toda transação de estoque com documento (compra recebida, venda emitida, transferência, devolução, ajuste, produção) é lançada, consultada, editada, finalizada, quitada e auditada. O Sol.NET expõe o mesmo formulário sob **três códigos** distintos na pesquisa universal, um por categoria:
 
 - [Movimentos de Compras](movimentos_de_compras.md) — código `201` — entrada de mercadoria com documento fiscal de compra.
-- [Movimentos de Vendas](movimentos_de_vendas.md) — código `202` — saída comercial (balcão, PDV, pedido faturado, OS faturada).
+- [Movimentos de Vendas](movimentos_de_vendas.md) — código `202` — saída comercial pela retaguarda (balcão, pedido faturado, OS faturada). Vendas em frente de caixa acontecem na aplicação **PDV**, à parte, documentada em outra seção.
 - [Outros Movimentos](outros_movimentos.md) — código `203` — transferências, ajustes, perdas, produção, brindes, consumo interno.
 
-Cada movimento amarra **um** [Tipo de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (cadastro `37`) e dele herda todas as regras: efeito no estoque (via `Transações de Estoque` — `33`), efeito no financeiro, fiscal (modelo, série, CFOPs), Funcionários exigidos, Tabela de Preço aplicada, Local de Estoque padrão, Portador, Condição de Pagamento padrão, regras de PDV/mobile/devolução/cashback.
+Cada movimento amarra **um** [Tipo de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (cadastro `37`) e dele herda todas as regras: efeito no estoque (via `Transações de Estoque` — `33`), efeito no financeiro, fiscal (modelo, série, CFOPs), Funcionários exigidos, Tabela de Preço aplicada, Local de Estoque padrão, Portador, Condição de Pagamento padrão, regras de mobile/devolução/cashback.
 
 ---
 
@@ -19,7 +19,7 @@ Cada movimento amarra **um** [Tipo de Movimento](../TiposDeMovimento/documentaca
 
 - [Movimentos — referência completa](documentacao_movimentos.md) — comportamento comum às três telas: mapa do formulário, sub-abas, fluxos principais (Lançar, Editar, Finalizar, Mudar, Quitar, Imprimir, Emitir NF-e, Estornar), atalhos validados, validações automáticas, exemplos práticos, telas relacionadas.
 - [Movimentos de Compras](movimentos_de_compras.md) — particularidades da tela `201` (CFOPs de entrada, atualização de custo, importação de XML, devolução para fornecedor).
-- [Movimentos de Vendas](movimentos_de_vendas.md) — particularidades da tela `202` (CFOPs de saída, PDV, NFC-e, cashback, ciclo Orçamento → Pedido → Venda).
+- [Movimentos de Vendas](movimentos_de_vendas.md) — particularidades da tela `202` (CFOPs de saída, ciclo Orçamento → Pedido → Venda, consulta de vendas vindas do PDV).
 - [Outros Movimentos](outros_movimentos.md) — particularidades da tela `203` (transferências, ajustes, perdas, produção, brindes).
 - [FAQ](faq.md) — perguntas frequentes e mensagens de validação ao salvar, finalizar e emitir fiscal.
 
@@ -32,7 +32,7 @@ O formulário se divide em duas grandes áreas:
 | Área | O que tem |
 |------|-----------|
 | **Consulta** | Lista de movimentos lançados, com sub-abas: `Movimentos` (geral + Produtos / Pagamentos / Observações / Protocolo Fiscal / Entrega PDV), `Contas PR` (Registros / Renegociação / Detalhes / Cheque / Cartão / Crédito Pessoa Usado/Gerado), `OS / Req.`, `Agrupar`, `Vínculos`, `Parcial` (Movimento Parcial + Quitação Parcial), `Chamada`, `Crédito - Gerado`, `Pesquisa PDV`, `Pesquisa Salva`, `Comportamentos`. |
-| **Lançamento** | Cabeçalho, Itens (com Totais / Tributação / ICMS/ST/IPI Livre / Pontos / Estoque do Produto / IVA), Campos Complementares, Descontos/Outras Despesas, Precificação (Custos / Preços / Buscador de Preço), Chamada, Cadastro/Fechamento, **Financeiro** (Contas / Parcelas / Rateio / Imagens / Forma de Pagamento), Entrega, Entrega PDV, MDF-e, Itens Cancelados, Vencimento (controle de lote/validade dos produtos), Outras Operações, PDV (quando o Tipo for PDV). |
+| **Lançamento** | Cabeçalho, Itens (com Totais / Tributação / ICMS/ST/IPI Livre / Pontos / Estoque do Produto / IVA), Campos Complementares, Descontos/Outras Despesas, Precificação (Custos / Preços / Buscador de Preço), Chamada, Cadastro/Fechamento, **Financeiro** (Contas / Parcelas / Rateio / Imagens / Forma de Pagamento), Entrega, Entrega PDV (para movimentos vindos do PDV), MDF-e, Itens Cancelados, Vencimento (controle de lote/validade dos produtos), Outras Operações. |
 
 Quais sub-abas aparecem em cada movimento depende inteiramente do `Tipo de Movimento` selecionado no Cabeçalho.
 

--- a/Movimentacao/Movimentos/README.md
+++ b/Movimentacao/Movimentos/README.md
@@ -1,0 +1,59 @@
+---
+title: "Índice: Movimentos — Movimentação Sol.NET"
+permalink: /Movimentacao/Movimentos/
+---
+
+# 📚 Movimentos — Sol.NET
+
+**Movimentos** é o coração operacional do módulo Movimentação: a tela onde toda transação de estoque com documento (compra recebida, venda emitida, transferência, devolução, ajuste, produção) é lançada, consultada, editada, finalizada, quitada e auditada. O Sol.NET expõe o mesmo formulário sob **três códigos** distintos na pesquisa universal, um por categoria:
+
+- [Movimentos de Compras](movimentos_de_compras.md) — código `201` — entrada de mercadoria com documento fiscal de compra.
+- [Movimentos de Vendas](movimentos_de_vendas.md) — código `202` — saída comercial (balcão, PDV, pedido faturado, OS faturada).
+- [Outros Movimentos](outros_movimentos.md) — código `203` — transferências, ajustes, perdas, produção, brindes, consumo interno.
+
+Cada movimento amarra **um** [Tipo de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (cadastro `37`) e dele herda todas as regras: efeito no estoque (via `Transações de Estoque` — `33`), efeito no financeiro, fiscal (modelo, série, CFOPs), Funcionários exigidos, Tabela de Preço aplicada, Local de Estoque padrão, Portador, Condição de Pagamento padrão, regras de PDV/mobile/devolução/cashback.
+
+---
+
+## 📄 Documentos desta seção
+
+- [Movimentos — referência completa](documentacao_movimentos.md) — comportamento comum às três telas: mapa do formulário, sub-abas, fluxos principais (Lançar, Editar, Finalizar, Mudar, Quitar, Imprimir, Emitir NF-e, Estornar), atalhos validados, validações automáticas, exemplos práticos, telas relacionadas.
+- [Movimentos de Compras](movimentos_de_compras.md) — particularidades da tela `201` (CFOPs de entrada, atualização de custo, importação de XML, devolução para fornecedor).
+- [Movimentos de Vendas](movimentos_de_vendas.md) — particularidades da tela `202` (CFOPs de saída, PDV, NFC-e, cashback, ciclo Orçamento → Pedido → Venda).
+- [Outros Movimentos](outros_movimentos.md) — particularidades da tela `203` (transferências, ajustes, perdas, produção, brindes).
+- [FAQ](faq.md) — perguntas frequentes e mensagens de validação ao salvar, finalizar e emitir fiscal.
+
+---
+
+## 🧭 Mapa rápido do formulário
+
+O formulário se divide em duas grandes áreas:
+
+| Área | O que tem |
+|------|-----------|
+| **Consulta** | Lista de movimentos lançados, com sub-abas: `Movimentos` (geral + Produtos / Pagamentos / Observações / Protocolo Fiscal / Entrega PDV), `Contas PR` (Registros / Renegociação / Detalhes / Cheque / Cartão / Crédito Pessoa Usado/Gerado), `OS / Req.`, `Agrupar`, `Vínculos`, `Parcial` (Movimento Parcial + Quitação Parcial), `Chamada`, `Crédito - Gerado`, `Pesquisa PDV`, `Pesquisa Salva`, `Comportamentos`. |
+| **Lançamento** | Cabeçalho, Itens (com Totais / Observações / Imposto Livre / Total Pontos / Estoque / IVA / Oculta), Outros Valores, Vencimento, Precificação, PDV (quando o Tipo for PDV), Campos Complementares. |
+
+Quais sub-abas aparecem em cada movimento depende inteiramente do `Tipo de Movimento` selecionado no Cabeçalho.
+
+---
+
+## ⌨️ Atalhos validados (resumo)
+
+| Tecla | Ação |
+|-------|------|
+| `F1` | Pesquisa universal de telas. |
+| `F6` | Finalizar. |
+| `F7` | Mudar (conversão automática entre Tipos). |
+| `F8` | Quitar. |
+| `F9` | Imprimir. |
+| `F10` | Emitir NF-e / NFC-e / NFS-e. |
+| `F11` | Estornar. |
+
+Funcionam **fora** do modo de pesquisa. Mais detalhes na [referência completa](documentacao_movimentos.md#%EF%B8%8F-atalhos-validados).
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 5.0
+**Público-alvo**: Usuários operacionais / Equipe de Suporte / Consultores de Implantação Sol.NET

--- a/Movimentacao/Movimentos/README.md
+++ b/Movimentacao/Movimentos/README.md
@@ -32,7 +32,7 @@ O formulário se divide em duas grandes áreas:
 | Área | O que tem |
 |------|-----------|
 | **Consulta** | Lista de movimentos lançados, com sub-abas: `Movimentos` (geral + Produtos / Pagamentos / Observações / Protocolo Fiscal / Entrega PDV), `Contas PR` (Registros / Renegociação / Detalhes / Cheque / Cartão / Crédito Pessoa Usado/Gerado), `OS / Req.`, `Agrupar`, `Vínculos`, `Parcial` (Movimento Parcial + Quitação Parcial), `Chamada`, `Crédito - Gerado`, `Pesquisa PDV`, `Pesquisa Salva`, `Comportamentos`. |
-| **Lançamento** | Cabeçalho, Itens (com Totais / Observações / Imposto Livre / Total Pontos / Estoque / IVA / Oculta), Outros Valores, Vencimento, Precificação, PDV (quando o Tipo for PDV), Campos Complementares. |
+| **Lançamento** | Cabeçalho, Itens (com Totais / Tributação / ICMS/ST/IPI Livre / Pontos / Estoque do Produto / IVA), Campos Complementares, Descontos/Outras Despesas, Precificação (Custos / Preços / Buscador de Preço), Chamada, Cadastro/Fechamento, **Financeiro** (Contas / Parcelas / Rateio / Imagens / Forma de Pagamento), Entrega, Entrega PDV, MDF-e, Itens Cancelados, Vencimento (controle de lote/validade dos produtos), Outras Operações, PDV (quando o Tipo for PDV). |
 
 Quais sub-abas aparecem em cada movimento depende inteiramente do `Tipo de Movimento` selecionado no Cabeçalho.
 

--- a/Movimentacao/Movimentos/documentacao_movimentos.md
+++ b/Movimentacao/Movimentos/documentacao_movimentos.md
@@ -51,14 +51,22 @@ O formulário se divide em **duas grandes áreas**: a área de **Consulta** (lis
 | Sub-aba | O que recebe |
 |---------|--------------|
 | **Cabeçalho** | Identificação do movimento: Tipo, Série, Número do Documento, Empresa, Pessoa, Datas (Emissão, E/S, Opcionais), Condição de Pagamento, Portador, Funcionários, Natureza de Operação, Modelo, Local de Estoque (origem e destino), Tabela de Preço. |
-| **Itens** | Produtos do movimento. Sub-abas: **Totais**, **Observações dos Itens**, **Imposto Livre**, **Total Pontos**, **Estoque** (visão por item), **IVA** (impostos consolidados), **Oculta** (campos técnicos não exibidos por padrão). |
-| **Outros Valores** | Acréscimos, descontos, fretes, despesas que afetam o total. |
-| **Vencimento** | Parcelas de vencimento do contas PR — gerado a partir da Condição de Pagamento e editável manualmente. |
-| **Precificação** | Aba auxiliar para revisão de preços antes de gravar. |
-| **PDV** | Disponível em Tipos marcados como PDV — interface de venda direta otimizada para teclado/balcão. |
+| **Itens** | Produtos do movimento. Sub-abas: **Totais**, **Tributação**, **ICMS/ST/IPI Livre**, **Pontos**, **Estoque do Produto**, **IVA** (impostos consolidados). |
 | **Campos Complementares** | Campos extras configurados em `Tipos de Movimento → Campos Livres`. |
+| **Descontos/Outras Despesas** | Acréscimos, descontos, fretes, despesas que afetam o total do movimento. |
+| **Precificação** | Aba auxiliar para revisão de preços antes de gravar. Sub-abas: **Custos**, **Preços**, **Buscador de Preço**. |
+| **Chamada** | Dados da chamada/atendimento vinculada ao movimento (quando o Tipo trabalha com Chamada). |
+| **Cadastro/Fechamento** | Dados de cadastro/fechamento associados (ex.: fechamento de comanda, abertura de OS). |
+| **Financeiro** | Contas a Pagar/Receber geradas pelo movimento. Sub-abas: **Contas** (títulos lançados), **Parcelas** (geração manual ou via Condição de Pagamento), **Rateio**, **Imagens** (anexos), **Forma de Pagamento**. |
+| **Entrega** | Dados de entrega — endereço, transportadora, prazos. |
+| **Entrega PDV** | Dados específicos de entrega para vendas originadas em PDV. |
+| **MDF-e** | Quando o movimento envolve transporte próprio: sub-abas **Rodoviário**, **Locais**, **Percurso/Condutor**, **Reboque**. |
+| **Itens Cancelados** | Itens removidos do movimento, mantidos para auditoria. |
+| **Vencimento** | **Controle de lote e data de validade dos produtos** do movimento — não tem relação com vencimento de parcelas (parcelas ficam em `Financeiro`). |
+| **Outras Operações** | Sub-abas auxiliares: **Informações** (Adicionais e Outras Info., como Município Origem/Destino para transporte). |
+| **PDV** | Disponível em Tipos marcados como PDV — interface de venda direta otimizada para teclado/balcão. |
 
-> 💡 **Quais sub-abas aparecem.** Cada Tipo de Movimento decide quais sub-abas ficam visíveis. Um Tipo `VENDA BALCÃO` mostra Cabeçalho + Itens + Outros Valores + Vencimento. Um Tipo `TRANSFERÊNCIA ENTRE LOJAS` mostra Cabeçalho + Itens (sem Vencimento, porque não gera financeiro). Um Tipo `DEVOLUÇÃO DE VENDA` mostra também a aba `Crédito Gerado`.
+> 💡 **Quais sub-abas aparecem.** Cada Tipo de Movimento decide quais sub-abas ficam visíveis. Um Tipo `VENDA BALCÃO` mostra Cabeçalho + Itens + Descontos/Outras Despesas + Financeiro. Um Tipo `TRANSFERÊNCIA ENTRE LOJAS` mostra Cabeçalho + Itens (sem Financeiro, porque não gera contas). Um Tipo `DEVOLUÇÃO DE VENDA` mostra também a aba `Crédito - Gerado` (na área de Consulta). Tipos que controlam produtos com lote/validade ativam a aba **Vencimento**; Tipos com transporte próprio ativam **MDF-e**.
 
 ---
 
@@ -73,8 +81,8 @@ O formulário se divide em **duas grandes áreas**: a área de **Consulta** (lis
    - Preencha `Pessoa` (cliente, fornecedor, funcionário — conforme o Tipo).
    - Ajuste `Série`, `Número do Documento`, `Datas`, `Local de Estoque`, `Tabela de Preço`, `Condição de Pagamento`, `Portador`, `Funcionários` (conforme exigências).
 4. Vá para a sub-aba **Itens** e adicione cada produto: código/nome, Quantidade, Preço (do produto ou da tabela), Desconto/Acréscimo.
-5. Em **Outros Valores**, se necessário, ajuste totais (frete, despesas, descontos no total).
-6. Em **Vencimento**, confira/edite as parcelas geradas a partir da Condição de Pagamento (válido para Tipos que geram financeiro).
+5. Em **Descontos/Outras Despesas**, se necessário, ajuste totais (frete, despesas, descontos no total).
+6. Em **Financeiro → Parcelas**, confira/edite as parcelas geradas a partir da Condição de Pagamento (válido para Tipos que geram financeiro).
 7. Pressione **Gravar** (ou `F6` para gravar e **finalizar** em um passo — ver atalhos abaixo).
 
 ### Editar um movimento já lançado
@@ -154,8 +162,8 @@ O formulário executa **centenas** de verificações distintas ao salvar, finali
 1. Pesquisa `F1` → `202` → **Novo**.
 2. **Cabeçalho**: `Tipo` = `VENDA BALCÃO`, `Pessoa` = cliente, `Local de Estoque` = `01 - Matriz`, `Condição de Pagamento` = `À VISTA`, `Portador` = `Caixa`.
 3. **Itens**: adicione cada produto. O preço vem da Tabela amarrada ao Tipo; ajuste desconto/quantidade conforme combinado.
-4. **Outros Valores**: se for o caso, lance frete ou desconto no total.
-5. **Vencimento**: parcela única confirmada automaticamente.
+4. **Descontos/Outras Despesas**: se for o caso, lance frete ou desconto no total.
+5. **Financeiro → Parcelas**: parcela única confirmada automaticamente.
 6. Pressione `F6` (Finalizar) → o sistema gera financeiro, baixa estoque e imprime cupom (se o Tipo tiver Relatório configurado).
 
 ### Exemplo 2 — Lançar entrada de NF de compra (`201`)
@@ -163,7 +171,7 @@ O formulário executa **centenas** de verificações distintas ao salvar, finali
 1. Pesquisa `F1` → `201` → **Novo**.
 2. **Cabeçalho**: `Tipo` = `COMPRA À VISTA` (ou `A PRAZO`), `Pessoa` = fornecedor, `Série` e `Número do Documento` = os da NF recebida, `Data de Emissão` = data da NF, `Data E/S` = data do recebimento físico.
 3. **Itens**: lance cada produto com `Custo` da nota. Se o Tipo tem `Atualizar Custo Automático` marcado em `Tipos de Movimento → Itens → Quantidade`, esse custo será propagado para o cadastro do produto ao gravar.
-4. **Vencimento**: confira parcelas conforme acordado com o fornecedor.
+4. **Financeiro → Parcelas**: confira parcelas conforme acordado com o fornecedor.
 5. `F6` (Finalizar) → estoque entra, financeiro a pagar é gerado, conta a pagar fica no `Contas PR`.
 
 ### Exemplo 3 — Transferência entre lojas (`203`)

--- a/Movimentacao/Movimentos/documentacao_movimentos.md
+++ b/Movimentacao/Movimentos/documentacao_movimentos.md
@@ -34,7 +34,7 @@ O formulário se divide em **duas grandes áreas**: a área de **Consulta** (lis
 
 | Sub-aba | Para quê serve |
 |---------|----------------|
-| **Movimentos** | Lista principal de movimentos lançados. Filtros por Tipo, período, Pessoa, status, Empresa, Local. Sub-painéis: **Produtos** (itens do movimento selecionado), **Pagamentos**, **Observações**, **Protocolo Fiscal**, **Entrega PDV**. |
+| **Movimentos** | Lista principal de movimentos lançados. Filtros por Tipo, período, Pessoa, status, Empresa, Local. Sub-painéis: **Produtos** (itens do movimento selecionado), **Pagamentos**, **Observações**, **Protocolo Fiscal**, **Entrega PDV** (dados de entrega quando o movimento veio do PDV). |
 | **Contas PR** | Títulos do contas a Pagar/Receber gerados por este movimento. Sub-abas: **Registros**, **Renegociação**, **Detalhes**, **Cheque** (com Histórico do Cheque), **Cartão**, **Crédito Pessoa - Usado**, **Crédito Pessoa - Gerado**. |
 | **OS / Req.** | Vínculos com Ordem de Serviço e OS-Requisição. |
 | **Agrupar** | Movimentos que foram agrupados — ver quais movimentos-origem compõem o movimento atual e vice-versa. |
@@ -42,7 +42,7 @@ O formulário se divide em **duas grandes áreas**: a área de **Consulta** (lis
 | **Parcial** | Sub-abas **Movimento Parcial** e **Quitação Parcial** — partes do movimento liberadas/quitadas em etapas. |
 | **Chamada** | Histórico de chamadas (atendimento) ligadas ao movimento. |
 | **Crédito - Gerado** | Créditos de pessoa gerados pelo movimento (devoluções, p.ex.). |
-| **Pesquisa PDV** | Filtros adicionais para movimentos originados em PDV. |
+| **Pesquisa PDV** | Filtros adicionais para **consultar** movimentos que se originaram no PDV (a aplicação de frente de caixa, documentada à parte). Esta tela apenas visualiza/edita o registro lançado por lá — não é onde se opera o PDV. |
 | **Pesquisa Salva** | Filtros pré-configurados pelo usuário (salvar uma consulta para reusar). |
 | **Comportamentos** | Configurações de visualização da própria tela (colunas, ordenação padrão). |
 
@@ -59,14 +59,15 @@ O formulário se divide em **duas grandes áreas**: a área de **Consulta** (lis
 | **Cadastro/Fechamento** | Dados de cadastro/fechamento associados (ex.: fechamento de comanda, abertura de OS). |
 | **Financeiro** | Contas a Pagar/Receber geradas pelo movimento. Sub-abas: **Contas** (títulos lançados), **Parcelas** (geração manual ou via Condição de Pagamento), **Rateio**, **Imagens** (anexos), **Forma de Pagamento**. |
 | **Entrega** | Dados de entrega — endereço, transportadora, prazos. |
-| **Entrega PDV** | Dados específicos de entrega para vendas originadas em PDV. |
+| **Entrega PDV** | Dados de entrega para vendas que **se originaram no PDV** — quando a retaguarda precisa completar ou ajustar essas informações. |
 | **MDF-e** | Quando o movimento envolve transporte próprio: sub-abas **Rodoviário**, **Locais**, **Percurso/Condutor**, **Reboque**. |
 | **Itens Cancelados** | Itens removidos do movimento, mantidos para auditoria. |
 | **Vencimento** | **Controle de lote e data de validade dos produtos** do movimento — não tem relação com vencimento de parcelas (parcelas ficam em `Financeiro`). |
 | **Outras Operações** | Sub-abas auxiliares: **Informações** (Adicionais e Outras Info., como Município Origem/Destino para transporte). |
-| **PDV** | Disponível em Tipos marcados como PDV — interface de venda direta otimizada para teclado/balcão. |
 
 > 💡 **Quais sub-abas aparecem.** Cada Tipo de Movimento decide quais sub-abas ficam visíveis. Um Tipo `VENDA BALCÃO` mostra Cabeçalho + Itens + Descontos/Outras Despesas + Financeiro. Um Tipo `TRANSFERÊNCIA ENTRE LOJAS` mostra Cabeçalho + Itens (sem Financeiro, porque não gera contas). Um Tipo `DEVOLUÇÃO DE VENDA` mostra também a aba `Crédito - Gerado` (na área de Consulta). Tipos que controlam produtos com lote/validade ativam a aba **Vencimento**; Tipos com transporte próprio ativam **MDF-e**.
+
+> ℹ️ **PDV é uma aplicação separada.** Tipos de Movimento com a flag `PDV` marcada (configurada em [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md)) **não aparecem** no combo `Tipo` em `Movimentos de Vendas` (`202`) — eles são exclusivos da aplicação `PDV` (frente de caixa), que será documentada à parte. Esta tela apenas **consulta** e, em alguns casos, **edita** registros que vieram do PDV (sub-abas `Pesquisa PDV` e `Entrega PDV`).
 
 ---
 
@@ -229,7 +230,7 @@ Mais perguntas e a referência completa de mensagens de erro em [FAQ](faq.md).
 | [Ajuste de Estoque](../documentacao_ajuste_de_estoque.md) | `79` | Tela auxiliar que **dispara** movimentos visíveis em `203`. |
 | `Pedido de Compra` | `64` | Tela que **dispara** movimentos em `201` ao ser convertido em entrada. |
 | [Produção de Produtos](../Producao/documentacao_producao_de_produtos.md) | `144` | **Dispara** movimentos visíveis em `203` (saída dos ingredientes, entrada do acabado, perda). |
-| [Regras Cashback](../documentacao_regras_cashback.md) | `124` | Tipos PDV podem disparar geração/uso de cashback ao finalizar. |
+| [Regras Cashback](../documentacao_regras_cashback.md) | `124` | Cashback é configurado por Tipo de Movimento e usado predominantemente pelo PDV (aplicação à parte). Movimentos vindos do PDV chegam aqui com o cashback já aplicado/gerado, visível nas sub-abas `Crédito Pessoa - Usado` / `Crédito Pessoa - Gerado`. |
 
 ---
 

--- a/Movimentacao/Movimentos/documentacao_movimentos.md
+++ b/Movimentacao/Movimentos/documentacao_movimentos.md
@@ -1,0 +1,240 @@
+# 📄 Movimentos - Sol.NET
+
+## 🎯 Visão Geral
+
+**Movimento** é o documento operacional que registra toda transação relevante no Sol.NET — uma compra recebida, uma venda emitida, uma transferência entre filiais, uma devolução, uma produção, um ajuste de inventário. Cada movimento amarra **um** [Tipo de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (cadastro `37`) e, por meio dele, herda todas as regras que determinam o efeito do lançamento: como o estoque é afetado (via [Transações de Estoque](../documentacao_transacoes_de_estoque.md) — cadastro `33`), qual financeiro gerar, qual fiscal emitir, em qual Local operar, qual Tabela de Preço aplicar, quais Funcionários exigir.
+
+O Sol.NET expõe o mesmo formulário operacional sob **três códigos** distintos na pesquisa universal — um para cada grande categoria de movimento. Esta página descreve o **comportamento comum** das três telas. As particularidades de cada modo estão nos perfis específicos:
+
+- [Movimentos de Compras](movimentos_de_compras.md) — código `201`.
+- [Movimentos de Vendas](movimentos_de_vendas.md) — código `202`.
+- [Outros Movimentos](outros_movimentos.md) — código `203`.
+
+> 💡 **Por que 3 telas para o "mesmo" formulário?** Cada código filtra, no momento da abertura, quais **Tipos de Movimento** estão disponíveis para seleção: `201` lista apenas Tipos com Comportamento `Entrada`; `202`, Tipos de `Saída`; `203`, Tipos `Outros` (transferências, perdas, ajustes, produção, devoluções neutras). O comportamento real do movimento — quais sub-abas aparecem, quais campos exigir, quais validações disparar — é decidido pelo Tipo selecionado, não pelo código de entrada.
+
+---
+
+## 🔑 Como acessar
+
+| Tela | Código (`F1`) | O que abre |
+|------|---------------|------------|
+| Movimentos de Compras | `201` | Formulário filtrado para Tipos de **Entrada**. |
+| Movimentos de Vendas | `202` | Formulário filtrado para Tipos de **Saída**. |
+| Outros Movimentos | `203` | Formulário filtrado para Tipos de Comportamento `Outros`. |
+
+Abra a pesquisa universal (atalho `F1`) e digite o código ou parte do nome da tela.
+
+---
+
+## 🧭 Mapa do formulário
+
+O formulário se divide em **duas grandes áreas**: a área de **Consulta** (lista de movimentos já lançados, com filtros) e a área de **Lançamento** (cabeçalho, itens, financeiro, totalizações, fiscal). Cada área agrupa várias sub-abas independentes — todas opcionais no sentido de que aparecem conforme o `Tipo de Movimento` configurar a tela.
+
+### 🔍 Consulta — sub-abas
+
+| Sub-aba | Para quê serve |
+|---------|----------------|
+| **Movimentos** | Lista principal de movimentos lançados. Filtros por Tipo, período, Pessoa, status, Empresa, Local. Sub-painéis: **Produtos** (itens do movimento selecionado), **Pagamentos**, **Observações**, **Protocolo Fiscal**, **Entrega PDV**. |
+| **Contas PR** | Títulos do contas a Pagar/Receber gerados por este movimento. Sub-abas: **Registros**, **Renegociação**, **Detalhes**, **Cheque** (com Histórico do Cheque), **Cartão**, **Crédito Pessoa - Usado**, **Crédito Pessoa - Gerado**. |
+| **OS / Req.** | Vínculos com Ordem de Serviço e OS-Requisição. |
+| **Agrupar** | Movimentos que foram agrupados — ver quais movimentos-origem compõem o movimento atual e vice-versa. |
+| **Vínculos** | Outras amarras explícitas com outros movimentos (referência fiscal, devolução, vínculo manual). |
+| **Parcial** | Sub-abas **Movimento Parcial** e **Quitação Parcial** — partes do movimento liberadas/quitadas em etapas. |
+| **Chamada** | Histórico de chamadas (atendimento) ligadas ao movimento. |
+| **Crédito - Gerado** | Créditos de pessoa gerados pelo movimento (devoluções, p.ex.). |
+| **Pesquisa PDV** | Filtros adicionais para movimentos originados em PDV. |
+| **Pesquisa Salva** | Filtros pré-configurados pelo usuário (salvar uma consulta para reusar). |
+| **Comportamentos** | Configurações de visualização da própria tela (colunas, ordenação padrão). |
+
+### 📝 Lançamento — sub-abas
+
+| Sub-aba | O que recebe |
+|---------|--------------|
+| **Cabeçalho** | Identificação do movimento: Tipo, Série, Número do Documento, Empresa, Pessoa, Datas (Emissão, E/S, Opcionais), Condição de Pagamento, Portador, Funcionários, Natureza de Operação, Modelo, Local de Estoque (origem e destino), Tabela de Preço. |
+| **Itens** | Produtos do movimento. Sub-abas: **Totais**, **Observações dos Itens**, **Imposto Livre**, **Total Pontos**, **Estoque** (visão por item), **IVA** (impostos consolidados), **Oculta** (campos técnicos não exibidos por padrão). |
+| **Outros Valores** | Acréscimos, descontos, fretes, despesas que afetam o total. |
+| **Vencimento** | Parcelas de vencimento do contas PR — gerado a partir da Condição de Pagamento e editável manualmente. |
+| **Precificação** | Aba auxiliar para revisão de preços antes de gravar. |
+| **PDV** | Disponível em Tipos marcados como PDV — interface de venda direta otimizada para teclado/balcão. |
+| **Campos Complementares** | Campos extras configurados em `Tipos de Movimento → Campos Livres`. |
+
+> 💡 **Quais sub-abas aparecem.** Cada Tipo de Movimento decide quais sub-abas ficam visíveis. Um Tipo `VENDA BALCÃO` mostra Cabeçalho + Itens + Outros Valores + Vencimento. Um Tipo `TRANSFERÊNCIA ENTRE LOJAS` mostra Cabeçalho + Itens (sem Vencimento, porque não gera financeiro). Um Tipo `DEVOLUÇÃO DE VENDA` mostra também a aba `Crédito Gerado`.
+
+---
+
+## 🔧 Fluxos principais
+
+### Lançar um movimento novo
+
+1. Abra a tela (`201`, `202` ou `203` conforme a categoria).
+2. Clique em **Novo** (ou pressione o botão equivalente).
+3. Na sub-aba **Cabeçalho**:
+   - Selecione o `Tipo de Movimento` — a partir deste momento o formulário se reconfigura (campos visíveis, obrigatoriedades, sub-abas).
+   - Preencha `Pessoa` (cliente, fornecedor, funcionário — conforme o Tipo).
+   - Ajuste `Série`, `Número do Documento`, `Datas`, `Local de Estoque`, `Tabela de Preço`, `Condição de Pagamento`, `Portador`, `Funcionários` (conforme exigências).
+4. Vá para a sub-aba **Itens** e adicione cada produto: código/nome, Quantidade, Preço (do produto ou da tabela), Desconto/Acréscimo.
+5. Em **Outros Valores**, se necessário, ajuste totais (frete, despesas, descontos no total).
+6. Em **Vencimento**, confira/edite as parcelas geradas a partir da Condição de Pagamento (válido para Tipos que geram financeiro).
+7. Pressione **Gravar** (ou `F6` para gravar e **finalizar** em um passo — ver atalhos abaixo).
+
+### Editar um movimento já lançado
+
+1. Localize o movimento na lista da sub-aba **Movimentos** (filtros por período, Pessoa, Tipo, status).
+2. Duplo-clique no registro (ou use o botão **Alterar** / `F7`).
+3. O formulário entra em modo de edição. Campos congelados pela situação do movimento (já finalizado, transmitido, quitado, com NF-e autorizada) ficam bloqueados — o que pode ser alterado depende da configuração do `Tipo de Movimento` e do estado atual.
+4. Faça os ajustes e **Grave** novamente.
+
+> ℹ️ **Correção Manual.** Quando o movimento já está em estado que normalmente bloqueia edição, alguns campos podem ainda ser ajustados pelo recurso *Correção Manual* — ele só pode ser acionado em **modo de pesquisa** (selecionando o registro na lista). Tentar acionar em modo de edição direta é bloqueado: *"Correção Manual permitido apenas em modo de Pesquisa"*.
+
+### Finalizar (botão **Finalizar** / `F6`)
+
+A finalização é o passo que **consolida** o movimento — gera o financeiro definitivo, baixa estoque conforme a Transação amarrada, emite o documento fiscal (se aplicável). Antes da finalização, validações cruzadas são executadas (caixa aberto, série fiscal disponível, campos obrigatórios, totalizações consistentes).
+
+### Mudar (botão **Mudar** / `F7`)
+
+Converte um movimento de um Tipo para outro **conforme regras configuradas** em `Cadastro de Tipos de Movimento → aba Mudar` — típico no ciclo `ORÇAMENTO → PEDIDO → VENDA`. A mudança copia os itens e o cabeçalho, ajustando o Tipo e re-aplicando regras fiscais/financeiras.
+
+### Quitar (botão **Quitar** / `F8`)
+
+Liquida os títulos do contas PR ligados ao movimento. Pode ser pelo total, por título individual ou por agrupamento. Variantes implementadas: `Quitar Multiplo`, `Quitar Contas PR`, `Quitar/Imprimir Só Portador`.
+
+### Imprimir (botão **Imprimir** / `F9`)
+
+Aciona o modelo de impressão vinculado ao Tipo (`Cadastro de Tipos de Movimento → aba Relatórios`). Pode imprimir DANFE, comprovante, espelho, ordem de serviço — conforme o que estiver configurado.
+
+### Emitir NF-e / NFC-e / NFS-e (botão **NF-e** / `F10`)
+
+Aciona a transmissão fiscal do documento eletrônico. O sistema gera o XML, assina, envia à SEFAZ/Prefeitura, recebe protocolo e atualiza o movimento com a Chave de Acesso. Status fiscais (`Autorizada`, `Rejeitada`, `Cancelada`, `Denegada`) ficam visíveis na sub-aba `Movimentos → Protocolo Fiscal`.
+
+### Estornar (botão **Estornar** / `F11`)
+
+Reverte completamente o efeito do movimento — devolve saldo ao estoque, cancela financeiro, cancela documento fiscal (quando permitido pela SEFAZ). A reversão é registrada e gera trilha de auditoria visível em `Histórico de Movimentações` (código `205`).
+
+---
+
+## ⌨️ Atalhos validados
+
+| Tecla | Ação |
+|-------|------|
+| `F1` | Abre a pesquisa universal de telas. |
+| `F6` | **Finalizar** o movimento atual. |
+| `F7` | **Mudar** o Tipo de Movimento (conversão automática). |
+| `F8` | **Quitar** os títulos vinculados. |
+| `F9` | **Imprimir** o movimento. |
+| `F10` | Emitir **NF-e / NFC-e / NFS-e**. |
+| `F11` | **Estornar** o movimento. |
+| `Esc` | Volta à sub-aba anterior dentro do Lançamento, ou fecha a pesquisa quando aberta como popup. |
+| `+` (numérico) | Quando configuração `UsarComanda` está ativa, abre a tela de **Comanda** a partir da consulta. |
+
+> ⚠️ Os atalhos `F6`–`F11` só funcionam **fora** do modo de pesquisa. Dentro da lista de busca, eles ficam inativos.
+
+---
+
+## ✅ Validações automáticas ao salvar e operar
+
+O formulário executa **centenas** de verificações distintas ao salvar, finalizar, mudar, quitar e estornar. As mensagens são exibidas em popup e o foco vai para o componente que causou. As mais frequentes estão organizadas por categoria no [FAQ](faq.md). Categorias cobertas:
+
+- **Cabeçalho** — Tipo de Movimento obrigatório, Pessoa obrigatória, Empresa permitida para o Tipo, Local de Estoque, Tabela de Preço, Funcionários (obrigatórios conforme configuração do Tipo).
+- **Itens** — pelo menos um item (*"Movimento sem item!"*), produtos com Tipo Movimento compatível (*"Empresa Não Permitida Para esse Tipo Movimento!"*), preço/custo dentro de faixas, quantidades positivas (ou negativas conforme o Tipo).
+- **Fiscal** — CFOP coerente com Comportamento (*"CFOP não é de entrada!"* / *"CFOP não é de saída!"*); estado/internacional (*"CFOP não é dentro do estado!"*, *"CFOP não é Exterior(Internacional)!"*); Chave de Acesso válida; Modelo × Série compatíveis.
+- **Caixa** — ao finalizar, verifica se o **Caixa** está aberto para o usuário/empresa (*"Caixa Aberto. Fechamento Nº: ( ... )"*).
+- **Financeiro** — parcelas com valor positivo, total das parcelas = total do movimento, Portador válido para a Condição de Pagamento.
+- **Pagamento SPED** — Tipos de pagamento SPED válidos para o documento eletrônico.
+- **Devolução** — quando o movimento é devolução, exige Movimento Referenciado (*"Não Permitido, Obrigatório Referenciar Nota! (Devolução)"*); a referência precisa ser da **mesma empresa** (*"Não Permitido, Obrigatório Referenciar Nota da Mesma Empresa! (Devolução)"*).
+- **Concorrência** — se outro usuário alterou Custo/Preço da Nota enquanto você editava: *"Alteraram o 'Custo' Antes de Voçê, Consulte a Nota de Novo!"* / *"Alteraram o 'Preço' Antes de Voçê, Consulte a Nota de Novo!"*.
+
+> 💡 Veja o [FAQ](faq.md) para a lista detalhada com **onde resolver cada mensagem**.
+
+---
+
+## 💡 Exemplos práticos
+
+### Exemplo 1 — Lançar uma venda balcão (`202`)
+
+1. Pesquisa `F1` → `202` → **Novo**.
+2. **Cabeçalho**: `Tipo` = `VENDA BALCÃO`, `Pessoa` = cliente, `Local de Estoque` = `01 - Matriz`, `Condição de Pagamento` = `À VISTA`, `Portador` = `Caixa`.
+3. **Itens**: adicione cada produto. O preço vem da Tabela amarrada ao Tipo; ajuste desconto/quantidade conforme combinado.
+4. **Outros Valores**: se for o caso, lance frete ou desconto no total.
+5. **Vencimento**: parcela única confirmada automaticamente.
+6. Pressione `F6` (Finalizar) → o sistema gera financeiro, baixa estoque e imprime cupom (se o Tipo tiver Relatório configurado).
+
+### Exemplo 2 — Lançar entrada de NF de compra (`201`)
+
+1. Pesquisa `F1` → `201` → **Novo**.
+2. **Cabeçalho**: `Tipo` = `COMPRA À VISTA` (ou `A PRAZO`), `Pessoa` = fornecedor, `Série` e `Número do Documento` = os da NF recebida, `Data de Emissão` = data da NF, `Data E/S` = data do recebimento físico.
+3. **Itens**: lance cada produto com `Custo` da nota. Se o Tipo tem `Atualizar Custo Automático` marcado em `Tipos de Movimento → Itens → Quantidade`, esse custo será propagado para o cadastro do produto ao gravar.
+4. **Vencimento**: confira parcelas conforme acordado com o fornecedor.
+5. `F6` (Finalizar) → estoque entra, financeiro a pagar é gerado, conta a pagar fica no `Contas PR`.
+
+### Exemplo 3 — Transferência entre lojas (`203`)
+
+1. Pesquisa `F1` → `203` → **Novo**.
+2. **Cabeçalho**: `Tipo` = `TRANSFERÊNCIA ENTRE EMPRESAS` (configurado em `37` com Comportamento `Outros`, destino Empresa), `Local Origem` = local da loja A, `Local Destino` / `Empresa Destino` = local da loja B.
+3. **Itens**: produtos a transferir, com quantidades.
+4. `F6` (Finalizar) → o Sol.NET baixa do Local Origem e entra no Local Destino. Não há financeiro porque o Tipo está configurado sem `Gerar Lançamento`.
+
+### Exemplo 4 — Devolução de venda gerando crédito ao cliente
+
+1. Pesquisa `F1` → `201` (ou `203`, conforme o Tipo `DEVOLUÇÃO DE VENDA` esteja cadastrado) → **Novo**.
+2. **Cabeçalho**: `Tipo` = `DEVOLUÇÃO DE VENDA`. **Referenciar Nota**: aponte para a venda original (o Tipo exige; sem isso a validação bloqueia).
+3. **Itens**: lance os produtos devolvidos.
+4. `F6` → estoque volta, fiscal de entrada é emitido, e (se o Tipo tem `Devolução Crédito` marcado em `37`) um **Crédito de Pessoa** é gerado para o cliente. O crédito aparece na sub-aba **Crédito - Gerado** desse movimento e na ficha da pessoa.
+
+### Exemplo 5 — Emitir NF-e de uma venda já finalizada
+
+1. Localize a venda em `202`, na sub-aba **Movimentos**.
+2. Selecione o registro e pressione `F10` (NF-e) — ou clique em `Emitir NF-e`.
+3. O sistema gera o XML, assina, envia à SEFAZ. O protocolo retorna na sub-aba `Movimentos → Protocolo Fiscal`.
+4. Se o status for `Rejeitada`, leia a mensagem da SEFAZ no Protocolo Fiscal e corrija conforme o erro (CFOP, NCM, alíquotas, IE do destinatário etc.) — depois `F10` de novo.
+
+---
+
+## ❓ FAQ rápido
+
+**Movimento foi gravado mas o saldo do produto não baixou.**
+A `Transação de Estoque` amarrada ao Tipo não está configurada para subtrair as camadas certas. Confira em `Transações de Estoque` (`33`) → confirme as colunas `Físico` e `Disponível`. Confira também o `Local de Estoque` informado no Cabeçalho — o saldo é por Local.
+
+**O combo `Tipo de Movimento` não mostra o Tipo que preciso.**
+O Tipo está inativo, ou está com Comportamento incompatível com a tela aberta (Entrada → `201`, Saída → `202`, Outros → `203`), ou o usuário não tem permissão no grupo de acesso desse Tipo.
+
+**Onde vejo o histórico completo das alterações deste movimento?**
+Em [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (código `205`) — todas as operações (gravação, edição, finalização, mudança, quitação, estorno, transmissão fiscal) ficam registradas com data, hora e usuário.
+
+**Lancei na tela errada (compra na `202` em vez de `201`).**
+Não há como lançar na tela errada, na verdade — o filtro de Tipos por Comportamento impede. Se a sensação é que o Tipo deveria estar disponível em outra tela, é a **configuração do Tipo** em `37` que está com Comportamento divergente. Ajuste lá.
+
+Mais perguntas e a referência completa de mensagens de erro em [FAQ](faq.md).
+
+---
+
+## 🔗 Telas relacionadas
+
+| Tela | Código (`F1`) | Como se relaciona |
+|------|---------------|--------------------|
+| [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) | `37` | Cada movimento herda **todas** suas regras do Tipo selecionado. Tela mais importante a entender em conjunto. |
+| [Transações de Estoque](../documentacao_transacoes_de_estoque.md) | `33` | O Tipo aponta para a Transação que decide o efeito de cada camada de saldo (Físico, Disponível, Reservado etc.). |
+| [Locais de Estoque](../documentacao_locais_de_estoque.md) | `28` | Identifica em qual armazém/loja o saldo afetado vive. Cabeçalho exige Local quando o Tipo movimenta estoque. |
+| [Tabela de Preço](../documentacao_tabela_de_preco.md) | `27` | Origem do `Preço` aplicado a cada item no Cabeçalho/Itens. |
+| [Saldo Estoque](../documentacao_saldo_estoque.md) | `78` | Visão consolidada do efeito dos movimentos nos saldos por Local/Situação. |
+| [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) | `205` | Trilha de auditoria do que aconteceu com cada movimento. |
+| [Histórico de Produtos](../documentacao_historico_de_produtos.md) | `206` | Filtra por produto — vê quais movimentos afetaram cada item. |
+| [Ajuste de Estoque](../documentacao_ajuste_de_estoque.md) | `79` | Tela auxiliar que **dispara** movimentos visíveis em `203`. |
+| `Pedido de Compra` | `64` | Tela que **dispara** movimentos em `201` ao ser convertido em entrada. |
+| [Produção de Produtos](../Producao/documentacao_producao_de_produtos.md) | `144` | **Dispara** movimentos visíveis em `203` (saída dos ingredientes, entrada do acabado, perda). |
+| [Regras Cashback](../documentacao_regras_cashback.md) | `124` | Tipos PDV podem disparar geração/uso de cashback ao finalizar. |
+
+---
+
+## ⚠️ Limites desta documentação
+
+- O formulário tem mais de **80 mil linhas de código** e **354 colunas** na tabela principal (`MOVIMENTOS`), além de 16 tabelas filhas (itens, parcelas, impostos, observações, comandas, referenciados etc.). Esta página é um **mapa de navegação** — não cobre cada campo individualmente.
+- A documentação cobre o **comportamento comum** das três telas (`201/202/203`). Para particularidades de cada modo, veja os perfis individuais.
+- Telas de **Conferência** (`209/210/211/220`) compartilham boa parte do código deste formulário mas operam em modo de leitura/conferência — serão documentadas em separado.
+- Detalhes profundos de **fiscal** (DANFE, regras de cada tipo de NF-e/NFC-e/NFS-e, contingência, manifesto, MDF-e) ficam na documentação do **módulo Fiscal**.
+- Regras de **comissão**, **promoção**, **cashback** e **agrupamento** são acionadas a partir das configurações do Tipo e tratadas em telas/documentações dedicadas.
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 5.0
+**Público-alvo**: Usuários operacionais (caixa, frente de loja, retaguarda) / Suporte

--- a/Movimentacao/Movimentos/documentacao_movimentos.md
+++ b/Movimentacao/Movimentos/documentacao_movimentos.md
@@ -75,6 +75,22 @@ O formulário se divide em **duas grandes áreas**: a área de **Consulta** (lis
 
 ## 🔧 Fluxos principais
 
+O ciclo de vida típico de um movimento e as operações disponíveis em cada estado:
+
+```mermaid
+flowchart TD
+  E[Em edição] -->|Gravar| L[Lançado]
+  L -->|F6 Finalizar| F[Finalizado]
+  L -->|F7 Mudar| M[Novo movimento<br/>com outro Tipo]
+  F -->|F7 Mudar| M
+  F -->|F11 Estornar| X[Estornado]
+  F -. F8 Quitar .-> Q[(Quita títulos)]
+  F -. F10 NF-e .-> NF[(Emite documento fiscal)]
+  F -. F9 Imprimir .-> P[(Impressão)]
+```
+
+Setas sólidas marcam transições de estado; setas pontilhadas marcam operações que produzem um artefato (quitação de título, emissão fiscal, impressão) sem mudar o estado do movimento. Os detalhes de cada operação estão a seguir.
+
 ### Lançar um movimento novo
 
 1. Abra a tela (`201`, `202` ou `203` conforme a categoria).

--- a/Movimentacao/Movimentos/documentacao_movimentos.md
+++ b/Movimentacao/Movimentos/documentacao_movimentos.md
@@ -40,7 +40,7 @@ O formulário se divide em **duas grandes áreas**: a área de **Consulta** (lis
 | **Contas PR** | Títulos do contas a Pagar/Receber gerados por este movimento. Sub-abas: **Registros**, **Renegociação**, **Detalhes**, **Cheque** (com Histórico do Cheque), **Cartão**, **Crédito Pessoa - Usado**, **Crédito Pessoa - Gerado**. |
 | **OS / Req.** | Vínculos com Ordem de Serviço e OS-Requisição. |
 | **Agrupar** | Movimentos que foram agrupados — ver quais movimentos-origem compõem o movimento atual e vice-versa. |
-| **Vínculos** | Outras amarras explícitas com outros movimentos (referência fiscal, devolução, vínculo manual). |
+| **Vínculos** | Outras amarras explícitas com outros movimentos (referência fiscal, devolução, vínculo manual) e a **pilha de movimentos gerada por Mudança Duplicar**, com o original em status `VINCULADO` apontando para o novo movimento que o substituiu. |
 | **Parcial** | Sub-abas **Movimento Parcial** e **Quitação Parcial** — partes do movimento liberadas/quitadas em etapas. |
 | **Chamada** | Histórico de chamadas (atendimento) ligadas ao movimento. |
 | **Crédito - Gerado** | Créditos de pessoa gerados pelo movimento (devoluções, p.ex.). |
@@ -81,15 +81,19 @@ O ciclo de vida típico de um movimento e as operações disponíveis em cada es
 flowchart TD
   E[Em edição] -->|Gravar| L[Lançado]
   L -->|F6 Finalizar| F[Finalizado]
-  L -->|F7 Mudar| M[Novo movimento<br/>com outro Tipo]
-  F -->|F7 Mudar| M
+  L -->|F7 Mudar| D{Modo configurado<br/>no Tipo?}
+  F -->|F7 Mudar| D
+  D -->|Transformar| F
+  D -->|Duplicar| N[Novo movimento<br/>com outro Tipo]
+  D -->|Duplicar| V[VINCULADO<br/>original congelado]
+  N -. pilha .-> V
   F -->|F11 Estornar| X[Estornado]
   F -. F8 Quitar .-> Q[(Quita títulos)]
   F -. F10 NF-e .-> NF[(Emite documento fiscal)]
   F -. F9 Imprimir .-> P[(Impressão)]
 ```
 
-Setas sólidas marcam transições de estado; setas pontilhadas marcam operações que produzem um artefato (quitação de título, emissão fiscal, impressão) sem mudar o estado do movimento. Os detalhes de cada operação estão a seguir.
+Setas sólidas marcam transições de estado; setas pontilhadas marcam operações que produzem um artefato (quitação de título, emissão fiscal, impressão) sem mudar o estado do movimento. O `F7 Mudar` passa por um **modo configurado no Tipo de destino** que decide se a mudança preserva o `ID_MOVIMENTO` (`Transformar`) ou gera um novo movimento com o original em status `VINCULADO` (`Duplicar`) — ver a seção `Mudar (botão Mudar / F7)` abaixo. Os detalhes de cada operação estão a seguir.
 
 ### Lançar um movimento novo
 
@@ -119,7 +123,12 @@ A finalização é o passo que **consolida** o movimento — gera o financeiro d
 
 ### Mudar (botão **Mudar** / `F7`)
 
-Converte um movimento de um Tipo para outro **conforme regras configuradas** em `Cadastro de Tipos de Movimento → aba Mudar` — típico no ciclo `ORÇAMENTO → PEDIDO → VENDA`. A mudança copia os itens e o cabeçalho, ajustando o Tipo e re-aplicando regras fiscais/financeiras.
+Converte um movimento de um Tipo para outro **conforme regras configuradas** em `Cadastro de Tipos de Movimento → aba Mudar` — típico no ciclo `ORÇAMENTO → PEDIDO → VENDA`. O Tipo de destino define **um de dois comportamentos**:
+
+- **Transformar** — o **mesmo movimento** muda de Tipo. O identificador interno do movimento é **preservado**; cabeçalho, fiscal e transações são reaplicados conforme o novo Tipo. Útil porque permite avançar o ciclo do movimento **sem exigir permissão de estorno** do usuário (equivalente prático a estornar + re-lançar, mas com tudo pré-definido pela configuração do Tipo).
+- **Duplicar** — um **novo movimento** é criado com o Tipo de destino e os itens copiados; o **original** muda de status para `VINCULADO` e fica **congelado** até que o novo seja cancelado. Forma uma **pilha** acessível pela sub-aba `Vínculos`. Útil quando o cliente quer **preservar histórico** de cada etapa (orçamento, pedido, faturamento são auditáveis separadamente).
+
+A escolha entre Transformar e Duplicar é decidida pelo cadastro do Tipo de destino, não pelo operador da tela. Ao apertar `F7`, o usuário não escolhe o modo — o sistema executa o que o Tipo dita.
 
 ### Quitar (botão **Quitar** / `F8`)
 

--- a/Movimentacao/Movimentos/documentacao_movimentos.md
+++ b/Movimentacao/Movimentos/documentacao_movimentos.md
@@ -18,11 +18,13 @@ O Sol.NET expõe o mesmo formulário operacional sob **três códigos** distinto
 
 | Tela | Código (`F1`) | O que abre |
 |------|---------------|------------|
-| Movimentos de Compras | `201` | Formulário filtrado para Tipos de **Entrada**. |
-| Movimentos de Vendas | `202` | Formulário filtrado para Tipos de **Saída**. |
-| Outros Movimentos | `203` | Formulário filtrado para Tipos de Comportamento `Outros`. |
+| Movimentos de Compras | `201` | Formulário com os Tipos da retaguarda de **entrada** (notas de fornecedor, devoluções para fornecedor, importações). |
+| Movimentos de Vendas | `202` | Formulário com os Tipos acessados por **vendedores** (venda balcão, orçamento, pedido de venda, OS faturada). |
+| Outros Movimentos | `203` | Formulário com os demais Tipos: transferências entre filiais, ajustes, perdas, produção, brindes, **devoluções de venda** e qualquer movimento que não seja fluxo de vendedor nem de recebimento fiscal de compra. |
 
 Abra a pesquisa universal (atalho `F1`) e digite o código ou parte do nome da tela.
+
+> 💡 **A regra prática de classificação.** A divisão entre as três telas não é apenas pelo Comportamento do Tipo (Entrada/Saída/Outros) — é também pelo **fluxo operacional** de quem usa o Tipo. Por isso devoluções de venda e transferências entre filiais, embora envolvam mercadoria saindo, ficam em `203` (são operadas pela retaguarda) e não em `202` (que é território do vendedor).
 
 ---
 
@@ -184,7 +186,7 @@ O formulário executa **centenas** de verificações distintas ao salvar, finali
 
 ### Exemplo 4 — Devolução de venda gerando crédito ao cliente
 
-1. Pesquisa `F1` → `201` (ou `203`, conforme o Tipo `DEVOLUÇÃO DE VENDA` esteja cadastrado) → **Novo**.
+1. Pesquisa `F1` → `203` (devolução de venda não fica em `202`, porque não é fluxo de vendedor — é retaguarda) → **Novo**.
 2. **Cabeçalho**: `Tipo` = `DEVOLUÇÃO DE VENDA`. **Referenciar Nota**: aponte para a venda original (o Tipo exige; sem isso a validação bloqueia).
 3. **Itens**: lance os produtos devolvidos.
 4. `F6` → estoque volta, fiscal de entrada é emitido, e (se o Tipo tem `Devolução Crédito` marcado em `37`) um **Crédito de Pessoa** é gerado para o cliente. O crédito aparece na sub-aba **Crédito - Gerado** desse movimento e na ficha da pessoa.

--- a/Movimentacao/Movimentos/faq.md
+++ b/Movimentacao/Movimentos/faq.md
@@ -130,8 +130,8 @@ A sub-aba de Consulta (`Movimentos`) tem filtros por período de emissão, Pesso
 
 Conferir nesta ordem:
 1. `Condição de Pagamento` no Cabeçalho — o número e os intervalos das parcelas saem dela.
-2. `Outros Valores` — acréscimo/desconto no total redistribui as parcelas.
-3. Edição manual na sub-aba `Vencimento` — alguém pode ter ajustado manualmente após a geração automática.
+2. `Descontos/Outras Despesas` — acréscimo/desconto no total redistribui as parcelas.
+3. Edição manual na sub-aba `Financeiro → Parcelas` — alguém pode ter ajustado manualmente após a geração automática.
 
 ---
 

--- a/Movimentacao/Movimentos/faq.md
+++ b/Movimentacao/Movimentos/faq.md
@@ -70,7 +70,7 @@ As validações abaixo se aplicam às três telas (`201` Compras, `202` Vendas, 
 | Mensagem | Quando aparece |
 |----------|----------------|
 | *"Erro ao Agrupar Movimento!"* | Falha ao agrupar dois ou mais movimentos. Conferir compatibilidade dos movimentos (Tipos diferentes, status diferentes). |
-| *"Erro ao Cadastrar o Cliente!"* | Cadastro automático de cliente (geralmente em PDV/NFC-e) falhou. Cadastrar manualmente em `Pessoas`. |
+| *"Erro ao Cadastrar o Cliente!"* | Cadastro automático de cliente (geralmente em integrações ou importações) falhou. Cadastrar manualmente em `Pessoas`. |
 | *"Erro ao Calcular!"* | Falha de cálculo de totais (preço × quantidade × desconto × impostos). Conferir valores numéricos. |
 | *"Erro ao Cancelar Financeiro!"* | Falha ao cancelar contas PR no estorno. Conferir se há quitação que precisa ser estornada primeiro. |
 | *"Erro ao gerar parcelas!"* / *"Erro ao gerar parcelas com valor negativo!"* | Falha ao gerar parcelas a partir da Condição de Pagamento. Conferir valor total e condição. |

--- a/Movimentacao/Movimentos/faq.md
+++ b/Movimentacao/Movimentos/faq.md
@@ -1,0 +1,148 @@
+# ❓ FAQ — Movimentos - Sol.NET
+
+Este FAQ concentra as **mensagens de validação** que aparecem ao lançar, finalizar, emitir fiscal, quitar e estornar movimentos, além das **perguntas mais frequentes** sobre comportamento do formulário. Para a referência completa, veja a [documentação](documentacao_movimentos.md). Para o panorama da seção, veja a [Visão Geral](README.md).
+
+As validações abaixo se aplicam às três telas (`201` Compras, `202` Vendas, `203` Outros), porque todas usam o mesmo formulário. As mensagens aparecem em popup e o foco vai para o campo que causou o problema.
+
+---
+
+## 🛡️ Validações ao salvar / finalizar — guia de troubleshooting
+
+### Cabeçalho — Tipo, Pessoa, Empresa
+
+| Mensagem | Causa | Onde resolver |
+|----------|-------|---------------|
+| *"Defina um Tipo de Movimento!"* | Tentou gravar sem selecionar um Tipo. | Cabeçalho → preencher `Tipo de Movimento`. |
+| *"Empresa Não Permitida Para esse Tipo Movimento!"* | A Empresa selecionada não está autorizada no Tipo escolhido. | Trocar Empresa ou ajustar o Tipo em [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) → aba `Outras Operações → Empresa`. |
+| *"Pessoa do Movimento Diferente da Pessoa da Chamada!"* | Vinculou uma `Chamada` cuja pessoa é diferente da pessoa do movimento. | Trocar a Chamada ou ajustar a pessoa. |
+
+### Fiscal — CFOP, Chave de Acesso, Cidade
+
+| Mensagem | Causa | Onde resolver |
+|----------|-------|---------------|
+| *"CFOP não é de entrada!"* | Tela `201` (Compras) com CFOP fora da faixa `1xxx/2xxx/3xxx`. | Ajustar a Natureza de Operação na Tipo de Movimento ou no Cabeçalho. |
+| *"CFOP não é de saída!"* | Tela `202` (Vendas) com CFOP fora da faixa `5xxx/6xxx/7xxx`. | Idem. |
+| *"CFOP não é dentro do estado!"* | Operação interna do estado (NFC-e típica) com CFOP interestadual/exterior. | Trocar Natureza de Operação. |
+| *"CFOP não é dentro do estado! (NFC-e)"* | NFC-e exige CFOP `5xxx` (dentro do estado). | Ajustar Natureza de Operação. |
+| *"CFOP não é fora do estado!"* | Inverso — esperava-se CFOP interestadual. | Idem. |
+| *"CFOP não é Exterior(Internacional)!"* | Operação de importação/exportação com CFOP interno. | Usar CFOP `3xxx` ou `7xxx`. |
+| *"Chave de Acesso Incorreta!"* | Chave de Acesso da NF referenciada está inválida (formato ou dígito verificador). | Recopiar a Chave do XML/DANFE original. |
+| *"Chave de Acesso já Criada Edição Parcial!"* | Tentou editar campos travados em movimento já com NF-e autorizada. | Usar `Correção Manual` em modo de pesquisa, ou cancelar/estornar antes. |
+| *"Cidade de Prestação sem Configuração de Tributação!"* | NFS-e sem configuração de tributação para a cidade do prestador. | Cadastro de Cidade (módulo Fiscal). |
+
+### Itens
+
+| Mensagem | Causa | Onde resolver |
+|----------|-------|---------------|
+| *"Movimento sem item!"* | Tentou gravar/finalizar sem nenhum produto. | Sub-aba `Itens` → adicionar ao menos uma linha. |
+| *"Empresa Não Permitida Para esse Tipo Movimento!"* (no item) | Produto não está autorizado para a Empresa/Tipo selecionados. | Cadastro do Produto / Tipo de Movimento. |
+| *"Deletar Produto Linkado Só Individualmente!"* | Tentou apagar em lote produtos com vínculo (ex.: bundle, fórmula). | Apagar um a um. |
+| *"Atualização de custo bloqueada para este tipo de movimento."* | Tentou recalcular custo num Tipo que não permite (ex.: Venda). | Operação só é válida em Tipos de Compra/Outros configurados. |
+| *"Erro ao Atualizar Custo!"* / *"Erro ao Recalcular Preços!"* | Falha de cálculo (provavelmente saldo inconsistente, custo zerado, divisão por zero). | Conferir o produto em `Saldo Estoque` (`78`) e o histórico em `Histórico de Produtos` (`206`). |
+| *"Alteraram o 'Custo' Antes de Voçê, Consulte a Nota de Novo!"* / *"Alteraram o 'Preço' Antes de Voçê, Consulte a Nota de Novo!"* | Outro usuário alterou custo/preço enquanto você editava o mesmo movimento. | Recarregar (consultar de novo) e refazer a alteração. |
+
+### Caixa, Quitação e Portador
+
+| Mensagem | Causa | Onde resolver |
+|----------|-------|---------------|
+| *"Caixa Aberto. Fechamento Nº: ( ... )"* / *"Caixa Aberto. Turno Nº: ( ... )"* | Caixa do usuário/empresa está aberto e bloqueia a operação que você tentou (ou exige que esteja aberto e não está). | Abrir/fechar o Caixa em `Caixa Geral - operação` (módulo Financeiro). |
+| *"Apenas Portador já impresso, podem ser limpo!"* | Tentou limpar portador de título não impresso. | Imprimir antes ou usar outro título. |
+| *"Apenas títulos com status 'ABERTOS, CANCELADOS' podem ser limpo o portador!"* | Tentou limpar portador de título quitado/parcial. | Estornar a quitação antes (se aplicável). |
+| *"Entrada inválida!"* / *"Entrada menor que o permitido"* / *"Entrada igual ou maior que o valor!"* | Valor de entrada na quitação fora dos limites configurados. | Ajustar o valor de entrada. |
+
+### Devolução e Vínculos
+
+| Mensagem | Causa | Onde resolver |
+|----------|-------|---------------|
+| *"Não Permitido, Obrigatório Referenciar Nota! (Devolução)"* | Tipo `DEVOLUÇÃO` exige `Movimento Referenciado` e ele está vazio. | Cabeçalho → `Referenciar Nota`. |
+| *"Não Permitido, Obrigatório Referenciar Nota da Mesma Empresa! (Devolução)"* | A NF referenciada pertence a outra empresa do grupo. | Selecionar uma NF da mesma empresa. |
+| *"Chamada Obrigatório!"* | Tipo exige amarra com Chamada e ela está vazia. | Cabeçalho → vincular Chamada. |
+| *"OS Obrigatório!"* / *"Empresa da 'OS' Diferente da 'OS-Requisição'!"* / *"Não Permitido, OS não Está em Aberto!"* | Validações de Ordem de Serviço vinculada — OS exigida, com mesma empresa e em aberto. | Aba `OS / Req.` — selecionar a OS correta. |
+
+### Tipo de Movimento divergente em operações disparadas
+
+| Mensagem | Causa | Onde resolver |
+|----------|-------|---------------|
+| *"Tipo de Movimento diferente do tipo escolhido em Ajuste de Estoque!"* | Você lançou um movimento direto em `203` que conflita com um ajuste em andamento de outro Tipo. | Conferir o `Tipo` selecionado contra o configurado em [Ajuste de Estoque](../documentacao_ajuste_de_estoque.md) (`79`). |
+
+### Erros genéricos
+
+| Mensagem | Quando aparece |
+|----------|----------------|
+| *"Erro ao Agrupar Movimento!"* | Falha ao agrupar dois ou mais movimentos. Conferir compatibilidade dos movimentos (Tipos diferentes, status diferentes). |
+| *"Erro ao Cadastrar o Cliente!"* | Cadastro automático de cliente (geralmente em PDV/NFC-e) falhou. Cadastrar manualmente em `Pessoas`. |
+| *"Erro ao Calcular!"* | Falha de cálculo de totais (preço × quantidade × desconto × impostos). Conferir valores numéricos. |
+| *"Erro ao Cancelar Financeiro!"* | Falha ao cancelar contas PR no estorno. Conferir se há quitação que precisa ser estornada primeiro. |
+| *"Erro ao gerar parcelas!"* / *"Erro ao gerar parcelas com valor negativo!"* | Falha ao gerar parcelas a partir da Condição de Pagamento. Conferir valor total e condição. |
+| *"Erro ao Excluir Crédito!"* | Falha ao excluir crédito de pessoa. Conferir se o crédito já foi usado em outro movimento. |
+| *"Erro ao Gravar no Banco de Dados os Itens!"* | Falha de gravação no banco. Costuma indicar problema de conexão ou integridade. Reabrir o movimento e tentar de novo; se persistir, abrir chamado para o suporte. |
+
+### Modo de operação
+
+| Mensagem | Causa | Onde resolver |
+|----------|-------|---------------|
+| *"Correção Manual permitido apenas em modo de Pesquisa"* | Tentou `Correção Manual` com o movimento já aberto em edição. | Fechar a edição, voltar à lista, selecionar o registro e acionar `Correção Manual` a partir dali. |
+| *"Essa função só pode ser utilizada em modo de Busca!"* | Operação só faz sentido sobre uma lista de resultados, não sobre um movimento aberto. | Voltar à sub-aba de Consulta. |
+| *"Escolha pelo menos Um(1) Movimento!"* | Operação em lote sem nada selecionado. | Selecionar ao menos uma linha. |
+
+---
+
+## ❓ Perguntas frequentes
+
+### Por que três telas para o mesmo formulário?
+
+Cada uma das telas (`201`, `202`, `203`) **filtra** os Tipos de Movimento disponíveis pelo `Comportamento` configurado em [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`): Entrada → `201`; Saída → `202`; Outros → `203`. O formulário em si é o mesmo, e o detalhe da operação (sub-abas visíveis, campos exigidos, fluxos disparados) sai do Tipo escolhido, não da tela.
+
+### O combo `Tipo de Movimento` não mostra o Tipo que preciso.
+
+Verifique nesta ordem:
+1. O Tipo está **Inativo**? → ative em `37`.
+2. O Tipo tem `Comportamento` compatível com a tela aberta? → `201` exige Entrada, `202` exige Saída, `203` exige Outros.
+3. O usuário tem permissão no **grupo de acesso** que inclui esse Tipo? → o controle é em telas de permissão fora deste cadastro; solicite ao administrador.
+
+### O movimento foi gravado mas o saldo do produto não baixou.
+
+A `Transação de Estoque` amarrada ao Tipo não está configurada para subtrair as camadas certas (`Físico`, `Disponível`). Abra [Transações de Estoque](../documentacao_transacoes_de_estoque.md) (`33`), localize a Transação amarrada ao Tipo do movimento e confira os marcadores. Verifique também o `Local de Estoque` informado no Cabeçalho — o saldo é por Local, e às vezes o que parece "não baixou" é "baixou no Local errado".
+
+### Onde vejo o histórico completo de alterações deste movimento?
+
+Em [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) — toda gravação, edição, finalização, mudança de Tipo, quitação, transmissão fiscal e estorno fica registrada com data, hora e usuário.
+
+### Como repor um movimento estornado?
+
+O estorno **não apaga** o movimento — ele apenas reverte o efeito (estoque, financeiro, fiscal). Para refazer, abra um **novo** movimento com os mesmos dados, ou (em casos específicos) acione `Mudar Tipo` (`F7`) sobre o estornado para mudar para um Tipo equivalente novo. Em hipótese alguma o estorno deve ser tratado como exclusão definitiva.
+
+### O sistema bloqueia a edição porque a NF-e já foi autorizada — o que fazer?
+
+Depende do que você precisa alterar:
+- **Campos não-fiscais** (observação, vendedor adicional) → usar `Correção Manual` em modo de pesquisa.
+- **Campos fiscais** (CFOP, alíquotas, produtos, valores) → emitir uma **Carta de Correção Eletrônica** (CC-e) quando aplicável (correções permitidas pela SEFAZ), **ou** cancelar a NF-e (dentro do prazo SEFAZ — geralmente 24h), estornar o movimento e refazer.
+
+### A finalização está bloqueada porque o Caixa está aberto / fechado.
+
+A mensagem é literal: o sistema diz se o Caixa precisa estar aberto e está fechado, ou se está aberto e precisa estar fechado. Abra ou feche o Caixa em `Caixa Geral - operação` (módulo Financeiro) conforme o que a mensagem indica.
+
+### Quero ver só os movimentos de um cliente / período / Tipo específicos.
+
+A sub-aba de Consulta (`Movimentos`) tem filtros por período de emissão, Pessoa, Tipo, status, Empresa, Local. Para filtros mais específicos ou repetidos, use **Pesquisa Salva** (sub-aba) para salvar a combinação e reusar.
+
+### O movimento gerou parcelas com valores estranhos.
+
+Conferir nesta ordem:
+1. `Condição de Pagamento` no Cabeçalho — o número e os intervalos das parcelas saem dela.
+2. `Outros Valores` — acréscimo/desconto no total redistribui as parcelas.
+3. Edição manual na sub-aba `Vencimento` — alguém pode ter ajustado manualmente após a geração automática.
+
+---
+
+## 🔗 Links
+
+- [Visão Geral](README.md) — papel dos Movimentos no Sol.NET e mapa rápido.
+- [Documentação](documentacao_movimentos.md) — referência completa do formulário (sub-abas, fluxos, atalhos).
+- [Movimentos de Compras](movimentos_de_compras.md) · [Movimentos de Vendas](movimentos_de_vendas.md) · [Outros Movimentos](outros_movimentos.md).
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 5.0
+**Público-alvo**: Usuários operacionais / Equipe de Suporte / Consultores de Implantação Sol.NET

--- a/Movimentacao/Movimentos/faq.md
+++ b/Movimentacao/Movimentos/faq.md
@@ -133,6 +133,10 @@ Conferir nesta ordem:
 2. `Descontos/Outras Despesas` — acréscimo/desconto no total redistribui as parcelas.
 3. Edição manual na sub-aba `Financeiro → Parcelas` — alguém pode ter ajustado manualmente após a geração automática.
 
+### O que significa o status `VINCULADO`?
+
+Aparece quando o movimento foi origem de uma **Mudança Duplicar** (`F7` com o Tipo de destino configurado como `Duplicar` em `Tipos de Movimento → aba Mudar`) e o novo movimento gerado está ativo. O original fica **congelado** nesse status — não aceita novas operações até que o subsequente (o "duplicado") seja cancelado, momento em que volta a aceitar ações. A pilha de movimentos relacionados fica visível na sub-aba `Vínculos`. Veja [Mudar (F7)](documentacao_movimentos.md#mudar-bot%C3%A3o-mudar--f7) para o conceito completo.
+
 ---
 
 ## 🔗 Links

--- a/Movimentacao/Movimentos/movimentos_de_compras.md
+++ b/Movimentacao/Movimentos/movimentos_de_compras.md
@@ -1,0 +1,70 @@
+# 📄 Movimentos de Compras - Sol.NET
+
+## 🎯 Visão Geral
+
+`Movimentos de Compras` é o ponto de entrada da operação **fiscal e de estoque de chegada**: notas fiscais de fornecedor, devoluções para fornecedor, recebimentos, importações, transferências de entrada vindas de outras lojas. Toda mercadoria que **entra** no estoque do Sol.NET por documento fiscal — ou o relacionamento fiscal de entrada equivalente — passa por aqui.
+
+A tela compartilha o mesmo formulário operacional usado em `Movimentos de Vendas` (`202`) e `Outros Movimentos` (`203`), mas **filtra os Tipos de Movimento disponíveis** apenas para aqueles com **Comportamento = Entrada** no [Cadastro de Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`).
+
+---
+
+## 🔑 Como acessar
+
+| | |
+|---|---|
+| **Tela** | Movimentos de Compras |
+| **Código (`F1`)** | `201` |
+
+Abra a pesquisa universal (`F1`) e digite `201` ou parte do nome **Movimentos de Compras**.
+
+---
+
+## 🧭 Particularidades do modo Compras
+
+Tudo o que diferencia esta tela das outras duas vem do **Tipo de Movimento** selecionado no Cabeçalho. Os Tipos de Compras tipicamente trazem:
+
+- **CFOPs de Entrada** (faixa `1xxx` para operações dentro do estado, `2xxx` para operações interestaduais, `3xxx` para importação). Tipo com CFOP fora da faixa é bloqueado ao gravar: *"CFOP não é de entrada!"*.
+- **Transações de Estoque que somam Físico/Disponível** — a entrada adiciona saldo, não consome.
+- **Tipos com Emissão = Terceiro** — a NF é de **outra** empresa (o fornecedor); o Sol.NET registra **Série** e **Número do Documento** vindos do papel/XML recebido, não numera localmente como faz nas Vendas.
+- **`Atualizar Custo Automático` válido** — em Compras, o custo informado **atualiza** o custo do produto (FIFO, médio ponderado ou último custo, conforme a configuração). É o lançamento de entrada que define o custo no Sol.NET. Vendas não atualizam custo (regra global validada em `37`).
+- **Devoluções para fornecedor** — Tipos como `DEVOLUÇÃO COMPRA` ficam aqui também (saída fiscal, mas categoricamente "compra ao contrário"). O fluxo exige **Movimento Referenciado** com a NF de compra original.
+- **Importação de XML** — fluxos de importação automática de NF-e de fornecedor (a partir do XML recebido) entram nesta tela; abrem o formulário com cabeçalho e itens já preenchidos a partir do XML.
+
+> 💡 **Não confunda com Pedido de Compra (`64`).** O `Pedido de Compra` é um documento **interno** (pré-compra) que **não** entra estoque nem gera financeiro definitivo. Ele apenas reserva e, ao ser convertido em entrada, **dispara** um movimento que aparece aqui em `201`. O efeito real de estoque/financeiro está no movimento de `201`, não no pedido.
+
+---
+
+## 💡 Exemplos práticos
+
+### Recebimento de NF-e do fornecedor (com XML)
+
+1. Pesquisa `F1` → `201` → **Importar XML** (botão; o caminho exato depende da personalização do menu).
+2. Selecione o XML da NF-e recebida. O Sol.NET preenche Cabeçalho e Itens automaticamente.
+3. Confira `Tipo de Movimento` proposto, `Local de Estoque` de entrada, `Vencimentos`.
+4. **Gravar** + **Finalizar** (`F6`) → estoque entra, conta a pagar é gerada.
+
+### Devolução para fornecedor
+
+1. Pesquisa `F1` → `201` → **Novo**.
+2. `Tipo` = `DEVOLUÇÃO COMPRA`.
+3. **Referenciar Nota** = NF de compra original (obrigatório — sem isso a validação bloqueia).
+4. **Itens** = produtos devolvidos com as mesmas quantidades.
+5. `F6` → estoque sai, fiscal de saída é emitido, conta a pagar original é abatida (conforme configuração do Tipo).
+
+---
+
+## 🔗 Documentação completa
+
+O detalhamento do formulário — sub-abas, fluxos, atalhos, validações, exemplos comuns, FAQ — está em [Movimentos](documentacao_movimentos.md). Esta página descreve apenas o que diferencia o modo `Compras`.
+
+Outras referências úteis:
+
+- [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) — onde os Tipos de Entrada são configurados.
+- [Transações de Estoque](../documentacao_transacoes_de_estoque.md) (`33`) — efeito da entrada nas camadas de saldo.
+- [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) — trilha de auditoria.
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 5.0
+**Público-alvo**: Equipe de recebimento / Retaguarda fiscal / Suporte

--- a/Movimentacao/Movimentos/movimentos_de_compras.md
+++ b/Movimentacao/Movimentos/movimentos_de_compras.md
@@ -2,9 +2,11 @@
 
 ## 🎯 Visão Geral
 
-`Movimentos de Compras` é o ponto de entrada da operação **fiscal e de estoque de chegada**: notas fiscais de fornecedor, devoluções para fornecedor, recebimentos, importações, transferências de entrada vindas de outras lojas. Toda mercadoria que **entra** no estoque do Sol.NET por documento fiscal — ou o relacionamento fiscal de entrada equivalente — passa por aqui.
+`Movimentos de Compras` é o ponto de entrada da operação **fiscal e de estoque de chegada**: notas fiscais de fornecedor, devoluções para fornecedor, recebimentos, importações. Toda mercadoria que **entra** com documento fiscal de compra é lançada aqui.
 
-A tela compartilha o mesmo formulário operacional usado em `Movimentos de Vendas` (`202`) e `Outros Movimentos` (`203`), mas **filtra os Tipos de Movimento disponíveis** apenas para aqueles com **Comportamento = Entrada** no [Cadastro de Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`).
+> ℹ️ **Transferências entre filiais** não ficam aqui — mesmo o lado da entrada de uma transferência. Transferências são operadas como movimentos auxiliares pela retaguarda e vivem em [Outros Movimentos](outros_movimentos.md) (`203`).
+
+A tela compartilha o mesmo formulário operacional usado em `Movimentos de Vendas` (`202`) e `Outros Movimentos` (`203`), mas **filtra os Tipos de Movimento disponíveis** para aqueles configurados em [Cadastro de Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) como entrada fiscal de compra.
 
 ---
 

--- a/Movimentacao/Movimentos/movimentos_de_compras.md
+++ b/Movimentacao/Movimentos/movimentos_de_compras.md
@@ -40,7 +40,7 @@ Tudo o que diferencia esta tela das outras duas vem do **Tipo de Movimento** sel
 
 1. Pesquisa `F1` → `201` → **Importar XML** (botão; o caminho exato depende da personalização do menu).
 2. Selecione o XML da NF-e recebida. O Sol.NET preenche Cabeçalho e Itens automaticamente.
-3. Confira `Tipo de Movimento` proposto, `Local de Estoque` de entrada, `Vencimentos`.
+3. Confira `Tipo de Movimento` proposto, `Local de Estoque` de entrada e as parcelas em `Financeiro`.
 4. **Gravar** + **Finalizar** (`F6`) → estoque entra, conta a pagar é gerada.
 
 ### Devolução para fornecedor

--- a/Movimentacao/Movimentos/movimentos_de_vendas.md
+++ b/Movimentacao/Movimentos/movimentos_de_vendas.md
@@ -27,7 +27,7 @@ Abra a pesquisa universal (`F1`) e digite `202` ou parte do nome **Movimentos de
 - **`Atualizar Custo Automático` proibido** — vendas **não** atualizam custo. Marcar essa flag em `37` para um Tipo de Saída é rejeitado: *"Atualizar Custo Automático, Somente para Compras/Outros!"*.
 - **PDV** — Tipos marcados como PDV em `Outras Operações → Sistema` ativam a sub-aba `PDV` no formulário, otimizada para venda balcão rápida (teclado, código de barras, finalização em poucos passos).
 - **Devolução de Venda** — quando um cliente devolve mercadoria, o Tipo `DEVOLUÇÃO DE VENDA` (configurado em `37` com `Devolução = Sim`) faz o movimento neste mesmo modo `202`, gerando Crédito de Pessoa quando configurado.
-- **Vencimento** — Tipos de venda costumam gerar contas a receber. As parcelas são derivadas da `Condição de Pagamento` do Cabeçalho e ficam visíveis/editáveis na sub-aba `Vencimento`.
+- **Financeiro** — Tipos de venda costumam gerar contas a receber. As parcelas são derivadas da `Condição de Pagamento` do Cabeçalho e ficam visíveis/editáveis na sub-aba `Financeiro → Parcelas`. (A aba `Vencimento`, à parte, é controle de **lote/data de validade dos produtos** — não de parcelas.)
 - **Caixa aberto** — para finalizar uma venda em modo PDV (ou em qualquer Tipo configurado para exigir Caixa), o Caixa do usuário precisa estar **aberto**; sem isso o sistema bloqueia: *"Caixa Aberto. Fechamento Nº: ( ... )"*.
 - **Cashback** — Tipos PDV podem disparar geração/uso de [Cashback](../documentacao_regras_cashback.md) automaticamente ao finalizar, conforme as Regras de Cashback ativas para a empresa/cliente.
 
@@ -40,7 +40,7 @@ Abra a pesquisa universal (`F1`) e digite `202` ou parte do nome **Movimentos de
 1. Pesquisa `F1` → `202` → **Novo**.
 2. **Cabeçalho**: `Tipo` = `VENDA BALCÃO`, `Pessoa` = cliente (ou genérico/consumidor final), `Condição de Pagamento` = `À VISTA`, `Portador` = `Caixa`.
 3. **Itens**: bipe ou digite cada produto; ajuste quantidade e desconto.
-4. **Outros Valores**: se necessário, lance desconto no total.
+4. **Descontos/Outras Despesas**: se necessário, lance desconto no total.
 5. `F6` (Finalizar) → estoque baixa, conta a receber é criada e imediatamente quitada (porque é à vista), cupom/NFC-e é emitido.
 
 ### Venda no PDV com NFC-e

--- a/Movimentacao/Movimentos/movimentos_de_vendas.md
+++ b/Movimentacao/Movimentos/movimentos_de_vendas.md
@@ -47,13 +47,15 @@ Abra a pesquisa universal (`F1`) e digite `202` ou parte do nome **Movimentos de
 
 ### Orçamento → Pedido → NFC-e (cupom fiscal)
 
-Cenário comum em loja de balcão. **Não é um comportamento automático da tela `202`** — todas as etapas dependem da configuração dos três [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) envolvidos. O fluxo abaixo descreve o que acontece quando os Tipos estão configurados no padrão típico de loja.
+Cenário comum em loja de balcão. **Não é um comportamento automático da tela `202`** — todas as etapas dependem da configuração dos três [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) envolvidos. O fluxo abaixo descreve o que acontece quando os Tipos estão configurados no padrão típico de loja: cada `F7 Mudar` aqui usa o modo **Transformar**, ou seja, é **o mesmo movimento mudando de Tipo** a cada etapa — não três movimentos distintos. O identificador interno é preservado, o que torna o ciclo executável mesmo por usuários sem permissão de estorno.
 
 ```mermaid
 flowchart TD
-  O["ORÇAMENTO<br/>(sem efeito no estoque<br/>nem no financeiro)"] -->|F7 Mudar| P["PEDIDO<br/>(estoque baixa<br/>financeiro aberto)"]
-  P -->|F7 Mudar| N["NFC-E CUPOM FISCAL<br/>(quitação dispara<br/>emissão fiscal inicia)"]
+  O["ORÇAMENTO<br/>(sem efeito no estoque<br/>nem no financeiro)"] -->|F7 Mudar Transformar| P["PEDIDO<br/>(estoque baixa<br/>financeiro aberto)"]
+  P -->|F7 Mudar Transformar| N["NFC-E CUPOM FISCAL<br/>(quitação dispara<br/>emissão fiscal inicia)"]
 ```
+
+> 💡 **Alternativa Duplicar.** Se o cliente preferir manter cada etapa como movimento separado e auditável, o Tipo `PEDIDO` (e o `NFC-E CUPOM FISCAL`) pode ser configurado no modo `Duplicar`. Nesse caso, o orçamento e o pedido **continuam existindo** com status `VINCULADO`, e a operação cria um novo movimento a cada `F7` — formando uma pilha visível em `Vínculos`. Ver [Mudar (F7)](documentacao_movimentos.md#mudar-bot%C3%A3o-mudar--f7) na documentação principal para entender Transformar vs Duplicar.
 
 1. **Lance um Tipo `ORÇAMENTO`** em `202`. O orçamento **não baixa estoque** e **não gera financeiro** — serve apenas para registrar a proposta ao cliente. *Configuração-chave do Tipo `ORÇAMENTO`*: `Itens → Estoque` sem Transação que afete saldo; `Financeiro → Financeiro 1` com `Gerar Lançamento` desligado; `Finalizar/Mudar → Mudar` apontando para o Tipo `PEDIDO`.
 2. **Cliente aprova → `F7` (Mudar)** transforma o `ORÇAMENTO` em `PEDIDO`. Neste momento, o **estoque é baixado** e o **financeiro é gerado** (conta a receber em aberto, com as parcelas da Condição de Pagamento escolhida). *Configuração-chave do Tipo `PEDIDO`*: `Itens → Estoque` com `Transação de Estoque` que subtrai `Físico` e `Disponível`; `Financeiro → Financeiro 1` com `Gerar Lançamento` ligado, Plano de Contas, Centro de Custo e Tipo de Documento Padrão definidos; `Finalizar/Mudar → Mudar` apontando para `NFC-E CUPOM FISCAL` (ou outro Tipo fiscal).

--- a/Movimentacao/Movimentos/movimentos_de_vendas.md
+++ b/Movimentacao/Movimentos/movimentos_de_vendas.md
@@ -2,7 +2,9 @@
 
 ## 🎯 Visão Geral
 
-`Movimentos de Vendas` é o ponto operacional da **saída comercial** do Sol.NET: vendas balcão, vendas no PDV (frente de loja), orçamentos, pedidos de venda, ordens de serviço com faturamento, faturamentos parciais, transferências de saída para outras lojas. Toda mercadoria que **sai** com nota fiscal de venda (ou documento equivalente) é lançada aqui.
+`Movimentos de Vendas` é o ponto operacional da **saída comercial** do Sol.NET na retaguarda: vendas balcão, orçamentos, pedidos de venda, ordens de serviço com faturamento, faturamentos parciais, transferências de saída para outras lojas. Toda mercadoria que **sai** com nota fiscal de venda (ou documento equivalente) e **não passa pelo PDV** é lançada aqui.
+
+> ℹ️ **PDV é separado.** Vendas em frente de caixa (cupom, NFC-e, comanda) acontecem em uma aplicação à parte, o **PDV**, que será documentada em outra seção. Tipos de Movimento marcados como `PDV` em [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) **não aparecem** no combo `Tipo` desta tela — só são selecionáveis pela aplicação PDV. Movimentos lançados no PDV ficam visíveis aqui apenas em modo de **consulta/edição complementar**.
 
 A tela compartilha o mesmo formulário operacional usado em `Movimentos de Compras` (`201`) e `Outros Movimentos` (`203`), mas **filtra os Tipos de Movimento disponíveis** apenas para aqueles com **Comportamento = Saída** no [Cadastro de Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`).
 
@@ -25,11 +27,10 @@ Abra a pesquisa universal (`F1`) e digite `202` ou parte do nome **Movimentos de
 - **Transações de Estoque que subtraem Físico/Disponível** — a venda consome saldo. Tipos cuja Transação não subtrai disparam erro de configuração no momento de finalizar.
 - **Emissão Própria** — a empresa emite o documento; `Série` e `Número do Documento` vêm da Série fiscal do Sol.NET, em sequência.
 - **`Atualizar Custo Automático` proibido** — vendas **não** atualizam custo. Marcar essa flag em `37` para um Tipo de Saída é rejeitado: *"Atualizar Custo Automático, Somente para Compras/Outros!"*.
-- **PDV** — Tipos marcados como PDV em `Outras Operações → Sistema` ativam a sub-aba `PDV` no formulário, otimizada para venda balcão rápida (teclado, código de barras, finalização em poucos passos).
 - **Devolução de Venda** — quando um cliente devolve mercadoria, o Tipo `DEVOLUÇÃO DE VENDA` (configurado em `37` com `Devolução = Sim`) faz o movimento neste mesmo modo `202`, gerando Crédito de Pessoa quando configurado.
 - **Financeiro** — Tipos de venda costumam gerar contas a receber. As parcelas são derivadas da `Condição de Pagamento` do Cabeçalho e ficam visíveis/editáveis na sub-aba `Financeiro → Parcelas`. (A aba `Vencimento`, à parte, é controle de **lote/data de validade dos produtos** — não de parcelas.)
-- **Caixa aberto** — para finalizar uma venda em modo PDV (ou em qualquer Tipo configurado para exigir Caixa), o Caixa do usuário precisa estar **aberto**; sem isso o sistema bloqueia: *"Caixa Aberto. Fechamento Nº: ( ... )"*.
-- **Cashback** — Tipos PDV podem disparar geração/uso de [Cashback](../documentacao_regras_cashback.md) automaticamente ao finalizar, conforme as Regras de Cashback ativas para a empresa/cliente.
+- **Caixa aberto** — Tipos configurados para exigir Caixa só finalizam se o Caixa do usuário estiver **aberto**; sem isso o sistema bloqueia: *"Caixa Aberto. Fechamento Nº: ( ... )"*.
+- **Vendas vindas do PDV** — vendas que se originaram no PDV (aplicação à parte) aparecem nas listas desta tela e podem ser consultadas/auditadas aqui. Filtros específicos estão na sub-aba `Pesquisa PDV` da área de Consulta. Cashback aplicado/gerado nessas vendas fica visível nas sub-abas `Crédito Pessoa - Usado` / `Crédito Pessoa - Gerado`.
 
 ---
 
@@ -41,14 +42,7 @@ Abra a pesquisa universal (`F1`) e digite `202` ou parte do nome **Movimentos de
 2. **Cabeçalho**: `Tipo` = `VENDA BALCÃO`, `Pessoa` = cliente (ou genérico/consumidor final), `Condição de Pagamento` = `À VISTA`, `Portador` = `Caixa`.
 3. **Itens**: bipe ou digite cada produto; ajuste quantidade e desconto.
 4. **Descontos/Outras Despesas**: se necessário, lance desconto no total.
-5. `F6` (Finalizar) → estoque baixa, conta a receber é criada e imediatamente quitada (porque é à vista), cupom/NFC-e é emitido.
-
-### Venda no PDV com NFC-e
-
-1. Pesquisa `F1` → `202` → **Novo** com Tipo PDV.
-2. A sub-aba `PDV` toma o foco — operação otimizada para teclado.
-3. Lance itens, escolha forma(s) de pagamento, conclua.
-4. NFC-e é emitida automaticamente; cliente recebe cupom.
+5. `F6` (Finalizar) → estoque baixa, conta a receber é criada e imediatamente quitada (porque é à vista), NF-e/NFS-e é emitida conforme o Tipo.
 
 ### Orçamento → Pedido → Venda
 
@@ -66,11 +60,11 @@ Outras referências úteis:
 
 - [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) — onde os Tipos de Saída são configurados.
 - [Tabela de Preço](../documentacao_tabela_de_preco.md) (`27`) — origem do preço aplicado a cada item.
-- [Regras Cashback](../documentacao_regras_cashback.md) (`124`) — regras que disparam cashback em vendas PDV.
+- [Regras Cashback](../documentacao_regras_cashback.md) (`124`) — regras de cashback (uso/geração) configuradas por Tipo; movimentos do PDV chegam aqui com o cashback já aplicado.
 - [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) — trilha de auditoria.
 
 ---
 
 **Última atualização**: Maio de 2026
 **Versão**: 5.0
-**Público-alvo**: Operadores de caixa e PDV / Vendedores / Retaguarda comercial / Suporte
+**Público-alvo**: Vendedores de balcão / Retaguarda comercial / Suporte

--- a/Movimentacao/Movimentos/movimentos_de_vendas.md
+++ b/Movimentacao/Movimentos/movimentos_de_vendas.md
@@ -49,6 +49,12 @@ Abra a pesquisa universal (`F1`) e digite `202` ou parte do nome **Movimentos de
 
 Cenário comum em loja de balcão. **Não é um comportamento automático da tela `202`** — todas as etapas dependem da configuração dos três [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) envolvidos. O fluxo abaixo descreve o que acontece quando os Tipos estão configurados no padrão típico de loja.
 
+```mermaid
+flowchart TD
+  O["ORÇAMENTO<br/>(sem efeito no estoque<br/>nem no financeiro)"] -->|F7 Mudar| P["PEDIDO<br/>(estoque baixa<br/>financeiro aberto)"]
+  P -->|F7 Mudar| N["NFC-E CUPOM FISCAL<br/>(quitação dispara<br/>emissão fiscal inicia)"]
+```
+
 1. **Lance um Tipo `ORÇAMENTO`** em `202`. O orçamento **não baixa estoque** e **não gera financeiro** — serve apenas para registrar a proposta ao cliente. *Configuração-chave do Tipo `ORÇAMENTO`*: `Itens → Estoque` sem Transação que afete saldo; `Financeiro → Financeiro 1` com `Gerar Lançamento` desligado; `Finalizar/Mudar → Mudar` apontando para o Tipo `PEDIDO`.
 2. **Cliente aprova → `F7` (Mudar)** transforma o `ORÇAMENTO` em `PEDIDO`. Neste momento, o **estoque é baixado** e o **financeiro é gerado** (conta a receber em aberto, com as parcelas da Condição de Pagamento escolhida). *Configuração-chave do Tipo `PEDIDO`*: `Itens → Estoque` com `Transação de Estoque` que subtrai `Físico` e `Disponível`; `Financeiro → Financeiro 1` com `Gerar Lançamento` ligado, Plano de Contas, Centro de Custo e Tipo de Documento Padrão definidos; `Finalizar/Mudar → Mudar` apontando para `NFC-E CUPOM FISCAL` (ou outro Tipo fiscal).
 3. **Faturar → `F7` novamente** transforma o `PEDIDO` em `NFC-E CUPOM FISCAL`. Neste momento, o sistema **dispara a quitação** dos títulos gerados na etapa anterior e, em sequência, **inicia a emissão do documento fiscal** (NFC-e enviada à SEFAZ, retorno com protocolo, cupom impresso). *Configuração-chave do Tipo `NFC-E CUPOM FISCAL`*: `Cabeçalho → Fiscal` com Modelo de Documento `NFC-e`, Série fiscal padrão e CFOPs `5xxx`; `Finalizar` configurado para quitar automaticamente; o efeito de estoque/financeiro **não se duplica** porque o `PEDIDO` já fez essa parte (o Tipo de mudança herda referência ao movimento-pai).

--- a/Movimentacao/Movimentos/movimentos_de_vendas.md
+++ b/Movimentacao/Movimentos/movimentos_de_vendas.md
@@ -45,11 +45,15 @@ Abra a pesquisa universal (`F1`) e digite `202` ou parte do nome **Movimentos de
 4. **Descontos/Outras Despesas**: se necessário, lance desconto no total.
 5. `F6` (Finalizar) → estoque baixa, conta a receber é criada e imediatamente quitada (porque é à vista), NF-e/NFS-e é emitida conforme o Tipo.
 
-### Orçamento → Pedido → Venda
+### Orçamento → Pedido → NFC-e (cupom fiscal)
 
-1. Lance um Tipo `ORÇAMENTO` em `202` — ele não baixa estoque nem gera financeiro (configurado assim em `37`).
-2. Quando o cliente aprovar, `F7` (Mudar) → mudança automática para `PEDIDO` (conforme regra de `Tipos de Movimento → aba Mudar`).
-3. Quando faturar, `F7` novamente → `VENDA`. Aí estoque desce e financeiro é gerado.
+Cenário comum em loja de balcão. **Não é um comportamento automático da tela `202`** — todas as etapas dependem da configuração dos três [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) envolvidos. O fluxo abaixo descreve o que acontece quando os Tipos estão configurados no padrão típico de loja.
+
+1. **Lance um Tipo `ORÇAMENTO`** em `202`. O orçamento **não baixa estoque** e **não gera financeiro** — serve apenas para registrar a proposta ao cliente. *Configuração-chave do Tipo `ORÇAMENTO`*: `Itens → Estoque` sem Transação que afete saldo; `Financeiro → Financeiro 1` com `Gerar Lançamento` desligado; `Finalizar/Mudar → Mudar` apontando para o Tipo `PEDIDO`.
+2. **Cliente aprova → `F7` (Mudar)** transforma o `ORÇAMENTO` em `PEDIDO`. Neste momento, o **estoque é baixado** e o **financeiro é gerado** (conta a receber em aberto, com as parcelas da Condição de Pagamento escolhida). *Configuração-chave do Tipo `PEDIDO`*: `Itens → Estoque` com `Transação de Estoque` que subtrai `Físico` e `Disponível`; `Financeiro → Financeiro 1` com `Gerar Lançamento` ligado, Plano de Contas, Centro de Custo e Tipo de Documento Padrão definidos; `Finalizar/Mudar → Mudar` apontando para `NFC-E CUPOM FISCAL` (ou outro Tipo fiscal).
+3. **Faturar → `F7` novamente** transforma o `PEDIDO` em `NFC-E CUPOM FISCAL`. Neste momento, o sistema **dispara a quitação** dos títulos gerados na etapa anterior e, em sequência, **inicia a emissão do documento fiscal** (NFC-e enviada à SEFAZ, retorno com protocolo, cupom impresso). *Configuração-chave do Tipo `NFC-E CUPOM FISCAL`*: `Cabeçalho → Fiscal` com Modelo de Documento `NFC-e`, Série fiscal padrão e CFOPs `5xxx`; `Finalizar` configurado para quitar automaticamente; o efeito de estoque/financeiro **não se duplica** porque o `PEDIDO` já fez essa parte (o Tipo de mudança herda referência ao movimento-pai).
+
+Variações comuns: um único Tipo `VENDA` que junta os passos 2 e 3 (para vendas sem orçamento prévio); pedido que termina em `NF-E` em vez de `NFC-e` (vendas com cliente identificado e fiscal completo); pedido que vira `OS` (ordem de serviço aberta) e só depois vira nota fiscal.
 
 ---
 

--- a/Movimentacao/Movimentos/movimentos_de_vendas.md
+++ b/Movimentacao/Movimentos/movimentos_de_vendas.md
@@ -1,0 +1,76 @@
+# 📄 Movimentos de Vendas - Sol.NET
+
+## 🎯 Visão Geral
+
+`Movimentos de Vendas` é o ponto operacional da **saída comercial** do Sol.NET: vendas balcão, vendas no PDV (frente de loja), orçamentos, pedidos de venda, ordens de serviço com faturamento, faturamentos parciais, transferências de saída para outras lojas. Toda mercadoria que **sai** com nota fiscal de venda (ou documento equivalente) é lançada aqui.
+
+A tela compartilha o mesmo formulário operacional usado em `Movimentos de Compras` (`201`) e `Outros Movimentos` (`203`), mas **filtra os Tipos de Movimento disponíveis** apenas para aqueles com **Comportamento = Saída** no [Cadastro de Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`).
+
+---
+
+## 🔑 Como acessar
+
+| | |
+|---|---|
+| **Tela** | Movimentos de Vendas |
+| **Código (`F1`)** | `202` |
+
+Abra a pesquisa universal (`F1`) e digite `202` ou parte do nome **Movimentos de Vendas**.
+
+---
+
+## 🧭 Particularidades do modo Vendas
+
+- **CFOPs de Saída** (faixa `5xxx` para operações dentro do estado, `6xxx` para interestaduais, `7xxx` para exportação). CFOP fora da faixa é bloqueado: *"CFOP não é de saída!"*.
+- **Transações de Estoque que subtraem Físico/Disponível** — a venda consome saldo. Tipos cuja Transação não subtrai disparam erro de configuração no momento de finalizar.
+- **Emissão Própria** — a empresa emite o documento; `Série` e `Número do Documento` vêm da Série fiscal do Sol.NET, em sequência.
+- **`Atualizar Custo Automático` proibido** — vendas **não** atualizam custo. Marcar essa flag em `37` para um Tipo de Saída é rejeitado: *"Atualizar Custo Automático, Somente para Compras/Outros!"*.
+- **PDV** — Tipos marcados como PDV em `Outras Operações → Sistema` ativam a sub-aba `PDV` no formulário, otimizada para venda balcão rápida (teclado, código de barras, finalização em poucos passos).
+- **Devolução de Venda** — quando um cliente devolve mercadoria, o Tipo `DEVOLUÇÃO DE VENDA` (configurado em `37` com `Devolução = Sim`) faz o movimento neste mesmo modo `202`, gerando Crédito de Pessoa quando configurado.
+- **Vencimento** — Tipos de venda costumam gerar contas a receber. As parcelas são derivadas da `Condição de Pagamento` do Cabeçalho e ficam visíveis/editáveis na sub-aba `Vencimento`.
+- **Caixa aberto** — para finalizar uma venda em modo PDV (ou em qualquer Tipo configurado para exigir Caixa), o Caixa do usuário precisa estar **aberto**; sem isso o sistema bloqueia: *"Caixa Aberto. Fechamento Nº: ( ... )"*.
+- **Cashback** — Tipos PDV podem disparar geração/uso de [Cashback](../documentacao_regras_cashback.md) automaticamente ao finalizar, conforme as Regras de Cashback ativas para a empresa/cliente.
+
+---
+
+## 💡 Exemplos práticos
+
+### Venda balcão à vista
+
+1. Pesquisa `F1` → `202` → **Novo**.
+2. **Cabeçalho**: `Tipo` = `VENDA BALCÃO`, `Pessoa` = cliente (ou genérico/consumidor final), `Condição de Pagamento` = `À VISTA`, `Portador` = `Caixa`.
+3. **Itens**: bipe ou digite cada produto; ajuste quantidade e desconto.
+4. **Outros Valores**: se necessário, lance desconto no total.
+5. `F6` (Finalizar) → estoque baixa, conta a receber é criada e imediatamente quitada (porque é à vista), cupom/NFC-e é emitido.
+
+### Venda no PDV com NFC-e
+
+1. Pesquisa `F1` → `202` → **Novo** com Tipo PDV.
+2. A sub-aba `PDV` toma o foco — operação otimizada para teclado.
+3. Lance itens, escolha forma(s) de pagamento, conclua.
+4. NFC-e é emitida automaticamente; cliente recebe cupom.
+
+### Orçamento → Pedido → Venda
+
+1. Lance um Tipo `ORÇAMENTO` em `202` — ele não baixa estoque nem gera financeiro (configurado assim em `37`).
+2. Quando o cliente aprovar, `F7` (Mudar) → mudança automática para `PEDIDO` (conforme regra de `Tipos de Movimento → aba Mudar`).
+3. Quando faturar, `F7` novamente → `VENDA`. Aí estoque desce e financeiro é gerado.
+
+---
+
+## 🔗 Documentação completa
+
+O detalhamento do formulário — sub-abas, fluxos, atalhos, validações, exemplos comuns, FAQ — está em [Movimentos](documentacao_movimentos.md). Esta página descreve apenas o que diferencia o modo `Vendas`.
+
+Outras referências úteis:
+
+- [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) — onde os Tipos de Saída são configurados.
+- [Tabela de Preço](../documentacao_tabela_de_preco.md) (`27`) — origem do preço aplicado a cada item.
+- [Regras Cashback](../documentacao_regras_cashback.md) (`124`) — regras que disparam cashback em vendas PDV.
+- [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) — trilha de auditoria.
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 5.0
+**Público-alvo**: Operadores de caixa e PDV / Vendedores / Retaguarda comercial / Suporte

--- a/Movimentacao/Movimentos/movimentos_de_vendas.md
+++ b/Movimentacao/Movimentos/movimentos_de_vendas.md
@@ -2,11 +2,13 @@
 
 ## 🎯 Visão Geral
 
-`Movimentos de Vendas` é o ponto operacional da **saída comercial** do Sol.NET na retaguarda: vendas balcão, orçamentos, pedidos de venda, ordens de serviço com faturamento, faturamentos parciais, transferências de saída para outras lojas. Toda mercadoria que **sai** com nota fiscal de venda (ou documento equivalente) e **não passa pelo PDV** é lançada aqui.
+`Movimentos de Vendas` concentra os Tipos de Movimento **acessados por vendedores** na retaguarda: venda balcão, orçamentos, pedidos de venda, ordens de serviço com faturamento, faturamentos parciais. É o conjunto de operações que um vendedor encontra no dia-a-dia para registrar uma saída comercial com cliente.
 
-> ℹ️ **PDV é separado.** Vendas em frente de caixa (cupom, NFC-e, comanda) acontecem em uma aplicação à parte, o **PDV**, que será documentada em outra seção. Tipos de Movimento marcados como `PDV` em [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) **não aparecem** no combo `Tipo` desta tela — só são selecionáveis pela aplicação PDV. Movimentos lançados no PDV ficam visíveis aqui apenas em modo de **consulta/edição complementar**.
+> ℹ️ **O que NÃO fica aqui:** devoluções de venda e transferências entre filiais — embora envolvam saída de mercadoria — **não** são fluxos de vendedor. Elas ficam em [Outros Movimentos](outros_movimentos.md) (`203`). A regra simples: se o Tipo de Movimento é tipicamente operado pela retaguarda/almoxarifado e não por um vendedor, ele vai para `203`.
 
-A tela compartilha o mesmo formulário operacional usado em `Movimentos de Compras` (`201`) e `Outros Movimentos` (`203`), mas **filtra os Tipos de Movimento disponíveis** apenas para aqueles com **Comportamento = Saída** no [Cadastro de Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`).
+> ℹ️ **PDV é separado.** Vendas em frente de caixa (cupom, NFC-e, comanda) acontecem em uma aplicação à parte, o **PDV**, que será documentada em outra seção. Tipos de Movimento marcados como `PDV` em [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) **não aparecem** no combo `Tipo` desta tela — são exclusivos da aplicação PDV. Movimentos lançados no PDV ficam visíveis aqui apenas em modo de **consulta/edição complementar**.
+
+A tela compartilha o mesmo formulário operacional usado em `Movimentos de Compras` (`201`) e `Outros Movimentos` (`203`), mas **filtra os Tipos de Movimento disponíveis** para aqueles configurados como vendas de vendedor em [Cadastro de Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`). Comportamento `Saída` é necessário mas não suficiente — outras flags (especialmente a exclusividade PDV) também filtram.
 
 ---
 
@@ -27,7 +29,6 @@ Abra a pesquisa universal (`F1`) e digite `202` ou parte do nome **Movimentos de
 - **Transações de Estoque que subtraem Físico/Disponível** — a venda consome saldo. Tipos cuja Transação não subtrai disparam erro de configuração no momento de finalizar.
 - **Emissão Própria** — a empresa emite o documento; `Série` e `Número do Documento` vêm da Série fiscal do Sol.NET, em sequência.
 - **`Atualizar Custo Automático` proibido** — vendas **não** atualizam custo. Marcar essa flag em `37` para um Tipo de Saída é rejeitado: *"Atualizar Custo Automático, Somente para Compras/Outros!"*.
-- **Devolução de Venda** — quando um cliente devolve mercadoria, o Tipo `DEVOLUÇÃO DE VENDA` (configurado em `37` com `Devolução = Sim`) faz o movimento neste mesmo modo `202`, gerando Crédito de Pessoa quando configurado.
 - **Financeiro** — Tipos de venda costumam gerar contas a receber. As parcelas são derivadas da `Condição de Pagamento` do Cabeçalho e ficam visíveis/editáveis na sub-aba `Financeiro → Parcelas`. (A aba `Vencimento`, à parte, é controle de **lote/data de validade dos produtos** — não de parcelas.)
 - **Caixa aberto** — Tipos configurados para exigir Caixa só finalizam se o Caixa do usuário estiver **aberto**; sem isso o sistema bloqueia: *"Caixa Aberto. Fechamento Nº: ( ... )"*.
 - **Vendas vindas do PDV** — vendas que se originaram no PDV (aplicação à parte) aparecem nas listas desta tela e podem ser consultadas/auditadas aqui. Filtros específicos estão na sub-aba `Pesquisa PDV` da área de Consulta. Cashback aplicado/gerado nessas vendas fica visível nas sub-abas `Crédito Pessoa - Usado` / `Crédito Pessoa - Gerado`.

--- a/Movimentacao/Movimentos/outros_movimentos.md
+++ b/Movimentacao/Movimentos/outros_movimentos.md
@@ -1,0 +1,80 @@
+# 📄 Outros Movimentos - Sol.NET
+
+## 🎯 Visão Geral
+
+`Outros Movimentos` é a porta de entrada para todos os documentos que **afetam estoque ou financeiro** mas **não são compra nem venda** em sentido comercial direto: transferências entre lojas/locais, ajustes de inventário, perdas, consumo interno, brindes, amostras grátis, entradas/saídas pelo Pedido de Compra ou pela Produção, devoluções neutras, doações.
+
+A tela compartilha o mesmo formulário operacional usado em `Movimentos de Compras` (`201`) e `Movimentos de Vendas` (`202`), mas **filtra os Tipos de Movimento disponíveis** apenas para aqueles com **Comportamento = Outros** no [Cadastro de Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`).
+
+---
+
+## 🔑 Como acessar
+
+| | |
+|---|---|
+| **Tela** | Outros Movimentos |
+| **Código (`F1`)** | `203` |
+
+Abra a pesquisa universal (`F1`) e digite `203` ou parte do nome **Outros Movimentos**.
+
+---
+
+## 🧭 Particularidades do modo Outros
+
+A categoria `Outros` é a mais **heterogênea** das três — cada Tipo aqui costuma ter sua configuração própria em `37`, porque o que essas operações têm em comum é só **não serem nem compra nem venda direta**. Cenários típicos:
+
+- **Transferências entre lojas/locais** — Comportamento `Outros` com `Tipo Empresa Destino` definido em `Cabeçalho → Origem/Destino` da configuração do Tipo. Estoque sai do `Local Origem` e entra no `Local Destino`, com ou sem documento fiscal próprio (NF de transferência) conforme a regra.
+- **Ajuste de Estoque** — o cadastro auxiliar `Ajuste de Estoque` (`79`) **dispara** movimentos visíveis aqui em `203`. O Tipo amarrado define se o ajuste é de entrada (positivo) ou saída (negativa). Veja [Ajuste de Estoque](../documentacao_ajuste_de_estoque.md).
+- **Produção de Produtos** — `Produção de Produtos` (`144`) também **dispara** movimentos em `203`: saída dos ingredientes, entrada do acabado, perda. Veja [Produção](../Producao/documentacao_producao_de_produtos.md).
+- **Pedido de Compra** convertido — `Pedido de Compra` (`64`) pode ser configurado para gerar movimento aqui em vez de em `201`, dependendo do desenho do cliente.
+- **Brindes, amostras, doações, consumo interno** — Tipos `Outros` que tipicamente saem do estoque sem financeiro, ou com financeiro de despesa.
+- **Devolução neutra** — quando a devolução não se enquadra como compra (sem refazer estoque do fornecedor) nem como venda (sem cliente final), pode ser cadastrada como `Outros` com regras dedicadas.
+
+> 💡 **CFOPs aceitos**: o validador do CFOP em `Outros` é mais flexível — não há restrição absoluta de faixa como em Entrada/Saída. Cada Tipo definirá em `Cabeçalho → Fiscal` quais CFOPs aceita.
+
+> ⚠️ **Atualizar Custo Automático**: válido em `Outros` (assim como em Compras). É comum em ajustes de inventário positivos e em entradas de produção (o produto acabado precisa de custo).
+
+---
+
+## 💡 Exemplos práticos
+
+### Transferência entre lojas
+
+1. Pesquisa `F1` → `203` → **Novo**.
+2. `Tipo` = `TRANSFERÊNCIA ENTRE EMPRESAS` (configurado em `37` com Comportamento `Outros`, `Tipo Empresa Destino` definido).
+3. **Cabeçalho**: `Local Origem` = local da loja A; `Empresa Destino` + `Local Destino` = loja B.
+4. **Itens**: produtos e quantidades.
+5. `F6` (Finalizar) → estoque sai do Local Origem e entra no Local Destino. Se o Tipo tem fiscal configurado, NF de transferência é emitida.
+
+### Lançar perda de estoque (quebra/avaria)
+
+1. Pesquisa `F1` → `203` → **Novo**.
+2. `Tipo` = `PERDA DE ESTOQUE`.
+3. **Itens**: produtos perdidos com quantidades.
+4. `F6` → estoque baixa, lançamento no Histórico fica disponível para auditoria.
+
+> 💡 Em vez de ir direto na `203`, prefira disparar a perda pelo cadastro auxiliar [Ajuste de Estoque](../documentacao_ajuste_de_estoque.md) (`79`) — ele cria o movimento aqui automaticamente, mas a inserção fica registrada na tela específica.
+
+### Entrada de produto acabado vindo da Produção
+
+1. Use o cadastro [Produção de Produtos](../Producao/documentacao_producao_de_produtos.md) (`144`) — ele dispara os movimentos em `203`.
+2. Para consultar/auditar: pesquisa `F1` → `203` → filtrar por Tipo (`PRODUÇÃO - ENTRADA ACABADO`, `PRODUÇÃO - SAÍDA INGREDIENTE`, `PRODUÇÃO - PERDA`).
+
+---
+
+## 🔗 Documentação completa
+
+O detalhamento do formulário — sub-abas, fluxos, atalhos, validações, exemplos comuns, FAQ — está em [Movimentos](documentacao_movimentos.md). Esta página descreve apenas o que diferencia o modo `Outros`.
+
+Outras referências úteis:
+
+- [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) — onde os Tipos `Outros` são configurados.
+- [Ajuste de Estoque](../documentacao_ajuste_de_estoque.md) (`79`) — telas auxiliares que disparam movimentos aqui.
+- [Produção de Produtos](../Producao/documentacao_producao_de_produtos.md) (`144`) — idem.
+- [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) — trilha de auditoria.
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 5.0
+**Público-alvo**: Retaguarda de estoque / Logística / Suporte

--- a/Movimentacao/Movimentos/outros_movimentos.md
+++ b/Movimentacao/Movimentos/outros_movimentos.md
@@ -2,9 +2,11 @@
 
 ## 🎯 Visão Geral
 
-`Outros Movimentos` é a porta de entrada para todos os documentos que **afetam estoque ou financeiro** mas **não são compra nem venda** em sentido comercial direto: transferências entre lojas/locais, ajustes de inventário, perdas, consumo interno, brindes, amostras grátis, entradas/saídas pelo Pedido de Compra ou pela Produção, devoluções neutras, doações.
+`Outros Movimentos` concentra os Tipos de Movimento operados pela **retaguarda/almoxarifado** — fluxos que não são compra fiscal de fornecedor (`201`) nem venda de vendedor (`202`): **transferências entre filiais/locais**, **devoluções de venda**, ajustes de inventário, perdas, consumo interno, brindes, amostras grátis, entradas/saídas disparadas por `Pedido de Compra` ou `Produção`, doações.
 
-A tela compartilha o mesmo formulário operacional usado em `Movimentos de Compras` (`201`) e `Movimentos de Vendas` (`202`), mas **filtra os Tipos de Movimento disponíveis** apenas para aqueles com **Comportamento = Outros** no [Cadastro de Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`).
+> 💡 É comum a devolução de venda parecer que "deveria estar em Vendas" — afinal, é uma venda voltando. A regra do Sol.NET segue o **operador**, não o sentido fiscal: devolução de venda é operada pela retaguarda (conferindo o que voltou, ajustando estoque, gerando crédito), por isso fica aqui.
+
+A tela compartilha o mesmo formulário operacional usado em `Movimentos de Compras` (`201`) e `Movimentos de Vendas` (`202`), mas **filtra os Tipos de Movimento disponíveis** para aqueles configurados em [Cadastro de Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) como movimentos de retaguarda (tipicamente Comportamento `Outros`; devolução de venda configurada como Entrada também recai aqui quando o Tipo é operacional, não de vendedor).
 
 ---
 
@@ -28,7 +30,8 @@ A categoria `Outros` é a mais **heterogênea** das três — cada Tipo aqui cos
 - **Produção de Produtos** — `Produção de Produtos` (`144`) também **dispara** movimentos em `203`: saída dos ingredientes, entrada do acabado, perda. Veja [Produção](../Producao/documentacao_producao_de_produtos.md).
 - **Pedido de Compra** convertido — `Pedido de Compra` (`64`) pode ser configurado para gerar movimento aqui em vez de em `201`, dependendo do desenho do cliente.
 - **Brindes, amostras, doações, consumo interno** — Tipos `Outros` que tipicamente saem do estoque sem financeiro, ou com financeiro de despesa.
-- **Devolução neutra** — quando a devolução não se enquadra como compra (sem refazer estoque do fornecedor) nem como venda (sem cliente final), pode ser cadastrada como `Outros` com regras dedicadas.
+- **Devolução de Venda** — quando o cliente devolve mercadoria já vendida, o Tipo `DEVOLUÇÃO DE VENDA` (configurado em `37` com `Devolução = Sim`, geralmente com `Devolução Crédito` para gerar crédito ao cliente) **fica aqui** em `203`, não em `202`. Exige `Referenciar Nota` apontando para a venda original. Estoque volta, fiscal de entrada é emitido, e (se configurado) um Crédito de Pessoa é gerado.
+- **Devolução neutra** — quando a devolução não se enquadra como compra (sem refazer estoque do fornecedor) nem como venda direta, pode ser cadastrada como `Outros` com regras dedicadas.
 
 > 💡 **CFOPs aceitos**: o validador do CFOP em `Outros` é mais flexível — não há restrição absoluta de faixa como em Entrada/Saída. Cada Tipo definirá em `Cabeçalho → Fiscal` quais CFOPs aceita.
 

--- a/Movimentacao/Producao/README.md
+++ b/Movimentacao/Producao/README.md
@@ -7,6 +7,23 @@ permalink: /Movimentacao/Producao/
 
 A produção interna do Sol.NET permite **cadastrar fórmulas** (receitas) e **executá-las**, disparando a criação automática dos movimentos de estoque correspondentes — saída dos insumos, entrada do produto acabado e (quando há) perda. Os movimentos disparados aparecem nas telas operacionais `Movimentos de Compras` (código `201`), `Movimentos de Vendas` (código `202`) ou `Outros Movimentos` (código `203`), conforme o Tipo de Movimento configurado para cada um. Esta seção concentra os dois cadastros centrais do fluxo.
 
+```mermaid
+flowchart TD
+  R[Fórmula cadastrada<br/>na tela 143] -. pré-requisito .-> F[Nova Produção<br/>na tela 144]
+  F -->|Iniciar Produção| I[Status: Iniciada]
+  I -->|Finalizar Produção| OK[Status: Finalizada]
+  I -->|Cancelar| C[Status: Cancelada]
+  OK --> M1[Movimento de saída<br/>dos ingredientes]
+  OK --> M2[Movimento de entrada<br/>do produto acabado]
+  OK --> M3[Movimento de perda<br/>quando a fórmula tem perdas]
+  M1 --> T{Vão para a tela<br/>operacional do Tipo<br/>de Movimento configurado}
+  M2 --> T
+  M3 --> T
+  T --> T1[201 Compras]
+  T --> T2[202 Vendas]
+  T --> T3[203 Outros]
+```
+
 ## 📄 Documentos disponíveis
 
 - [Cadastro de Fórmula de Produtos](documentacao_formulas_de_produtos.md) — tela `143`. Define a receita: produto acabado, ingredientes, perdas, proporção (Fator × Total).

--- a/Movimentacao/README.md
+++ b/Movimentacao/README.md
@@ -5,6 +5,35 @@ permalink: /Movimentacao/
 
 # 📚 Documentação do Módulo Movimentação — Sol.NET
 
-> 🚧 **Em reescrita.** O conteúdo anterior deste módulo foi descartado e está sendo refeito do zero, no mesmo padrão usado em [Financeiro](../Financeiro/) — uma página por tela, ancorada no código-fonte e em consultas ao banco. Novos documentos serão listados aqui à medida que forem publicados.
+> 🚧 **Em reescrita.** O conteúdo anterior deste módulo foi descartado e está sendo refeito do zero, no mesmo padrão usado em [Financeiro](../Financeiro/) — uma página por tela, ancorada no código-fonte e em consultas ao banco. Novos documentos são listados aqui à medida que forem publicados. Dúvidas pontuais sobre telas ainda não cobertas podem ser respondidas pelo suporte Hetosoft.
 
-Enquanto isso, dúvidas pontuais podem ser respondidas pelo suporte Hetosoft.
+---
+
+## 📄 Documentos publicados
+
+### Operação — onde os movimentos acontecem
+
+- **[Movimentos](Movimentos/)** — trio operacional `Movimentos de Compras` (`201`), `Movimentos de Vendas` (`202`), `Outros Movimentos` (`203`). Subpasta com referência completa, perfil por tela e FAQ.
+
+### Configuração — o que define o comportamento da operação
+
+- **[Tipos de Movimento](TiposDeMovimento/)** — `37`. Configura todas as regras herdadas pelos movimentos.
+- [Transações de Estoque](documentacao_transacoes_de_estoque.md) — `33`. Define o efeito em cada camada de saldo.
+- [Locais de Estoque](documentacao_locais_de_estoque.md) — `28`.
+- [Tabela de Preço](documentacao_tabela_de_preco.md) — `27`.
+- [Regras Cashback](documentacao_regras_cashback.md) — `124`.
+
+### Consulta — saldos e histórico
+
+- [Saldo Estoque](documentacao_saldo_estoque.md) — `78`.
+- [Histórico de Movimentações](documentacao_historico_de_movimentacoes.md) — `205`.
+- [Histórico de Produtos](documentacao_historico_de_produtos.md) — `206`.
+
+### Operações auxiliares — disparam movimentos visíveis no trio `201/202/203`
+
+- [Ajuste de Estoque](documentacao_ajuste_de_estoque.md) — `79`.
+- **[Produção](Producao/)** — `Fórmulas de Produtos` (`143`) + `Produção de Produtos` (`144`).
+
+---
+
+> 💡 As telas `Pedido de Compra` (`64`), `Cadastro de Produtos` (`32`), Conferências (`209/210/211/220`) e os guias temáticos cross-tela (Atualização de Custo, Cashback no PDV, Preço de Venda, Tabela de Preço — Fallback) ainda estão em fila de reescrita.

--- a/Movimentacao/TiposDeMovimento/README.md
+++ b/Movimentacao/TiposDeMovimento/README.md
@@ -5,7 +5,7 @@ permalink: /Movimentacao/TiposDeMovimento/
 
 # 📚 Cadastro de Tipos de Movimento — Sol.NET
 
-O **Tipo de Movimento** é a **identidade operacional** de cada lançamento no Sol.NET. Ele responde, em um único cadastro, a perguntas que todo movimento precisa carregar: *é venda ou compra?*, *sai ou entra no estoque?*, *é nota fiscal própria ou de terceiro?*, *qual CFOP, qual modelo de documento, qual série?*, *gera financeiro?*, *atualiza custo?*, *é PDV, mobile, ordem de serviço?*. Tudo o que diferencia uma venda de balcão de uma venda no PDV, ou uma compra à vista de uma compra parcelada, está aqui.
+O **Tipo de Movimento** é a **identidade operacional** de cada lançamento no Sol.NET. Ele responde, em um único cadastro, a perguntas que todo movimento precisa carregar: *é venda ou compra?*, *sai ou entra no estoque?*, *é nota fiscal própria ou de terceiro?*, *qual CFOP, qual modelo de documento, qual série?*, *gera financeiro?*, *atualiza custo?*, *é mobile, ordem de serviço?*, *é exclusivo da aplicação PDV?*. Tudo o que diferencia uma venda de balcão de uma devolução, ou uma compra à vista de uma compra parcelada, está aqui.
 
 Cada movimento operacional (em `Movimentos de Compras` código `201`, `Movimentos de Vendas` código `202`, `Outros Movimentos` código `203`, e também as ações disparadas por `Pedido de Compra` código `64`, `Produção de Produtos` código `144` e `Ajuste de Estoque` código `79`) aponta para **um** Tipo de Movimento — e é dele que o Sol.NET extrai todas as regras: quais Tabelas de Preço aceitar, qual `Transação de Estoque` aplicar, qual `Tipo de Documento Padrão` usar no financeiro, qual layout fiscal emitir, quais campos exigir, em qual `Local de Estoque` operar, com qual `Portador` quitar.
 

--- a/Movimentacao/TiposDeMovimento/documentacao_tipos_de_movimento.md
+++ b/Movimentacao/TiposDeMovimento/documentacao_tipos_de_movimento.md
@@ -2,7 +2,7 @@
 
 ## 🎯 Visão Geral
 
-O **Tipo de Movimento** é a configuração que define **como** cada movimento operacional (compra, venda, devolução, transferência, ajuste, produção, pedido) se comporta no Sol.NET. Ele concentra dezenas de regras — comportamento de estoque, regras fiscais, geração de financeiro, comissão, regras de PDV, mobile, agrupamento, finalização — em um único registro reutilizável.
+O **Tipo de Movimento** é a configuração que define **como** cada movimento operacional (compra, venda, devolução, transferência, ajuste, produção, pedido) se comporta no Sol.NET. Ele concentra dezenas de regras — comportamento de estoque, regras fiscais, geração de financeiro, comissão, exclusividade da aplicação PDV, mobile, agrupamento, finalização — em um único registro reutilizável.
 
 Para um panorama do papel do Tipo de Movimento no Sol.NET e o mapa das 12 abas do formulário, veja a [Visão Geral](README.md). Para troubleshooting das mensagens de bloqueio ao gravar, veja o [FAQ](faq.md).
 
@@ -119,6 +119,8 @@ Aba "guarda-tudo" de comportamentos especiais — alvo de muitas validações cr
 | **Empresa → Empresa 1 / Empresa 2 / extras** | Comportamentos por empresa-destino do movimento. |
 | **Sistema** | Flags de sistema — PDV, Mobile, OS × OS Requisição, Devolução, Crédito Pessoa, Quitar Crédito Automaticamente. As validações cruzadas mais comuns aparecem no [FAQ](faq.md). |
 
+> ℹ️ **Flag `PDV`.** Marcar `PDV` aqui **não altera** o comportamento do Tipo nas telas `Movimentos de Compras/Vendas/Outros` (`201/202/203`) — em vez disso, **torna o Tipo exclusivo da aplicação PDV** (frente de caixa), que é um sistema à parte do ponto de vista do usuário (mesmo Sol.NET compilado em modo PDV). Tipos com `PDV` marcado **não aparecem** no combo `Tipo` das telas de Movimentos da retaguarda — só são selecionáveis dentro do PDV. A aplicação PDV será documentada em outra seção.
+
 ---
 
 ## 🌿 Aba `Agrotóxico`
@@ -188,9 +190,11 @@ Este Tipo passa a aparecer como opção em `Movimentos de Compras` (código `201
 5. Aba **Outras Operações → Sistema**:
    - `Devolução` = `Sim`.
    - `Devolução Crédito` ≥ `0` (gera crédito).
-   - Se for PDV, marque `Quitar Crédito Automaticamente` para abater o crédito direto na próxima compra.
-6. Aba **Financeiro → Financeiro 1**: `Não Estornar Financeiro` se for compra (válido), ou deixe vazio para vendas (não permitido para Vendas; o erro avisa).
+   - Se este Tipo for usado exclusivamente pela aplicação PDV (frente de caixa), marque `PDV` + `Quitar Crédito Automaticamente` — assim o crédito é abatido direto na próxima compra dentro do PDV. Para devoluções operadas pela retaguarda, deixe `PDV` desmarcado.
+6. Aba **Financeiro → Financeiro 1**: `Não Estornar Financeiro` quando aplicável (válido para Tipos de Compras/Outros; bloqueado em Vendas).
 7. **Gravar**.
+
+Este Tipo passa a aparecer como opção em `Outros Movimentos` (código `203`) — devoluções de venda são operadas pela retaguarda, não por vendedores em `202`. Se a flag `PDV` for marcada, o Tipo deixa de aparecer nessas três telas e fica exclusivo da aplicação PDV.
 
 ### Exemplo 4 — Inativar um Tipo legado sem perder histórico
 

--- a/Movimentacao/TiposDeMovimento/documentacao_tipos_de_movimento.md
+++ b/Movimentacao/TiposDeMovimento/documentacao_tipos_de_movimento.md
@@ -95,7 +95,7 @@ A aba **Itens** é a maior em volume de regras — controla o que o movimento ac
 | Aba | O que configura |
 |-----|-----------------|
 | **Finalizar** | O que acontece quando o movimento é finalizado — botões, validações finais, geração de documentos. Inclui sub-aba `Finalizar / Mudar` que liga este Tipo a outro (ex.: `PEDIDO → VENDA` ao finalizar). |
-| **Mudar** | Configura uma **mudança automática** deste tipo para outro durante o ciclo (ex.: orçamento que vira pedido que vira venda). |
+| **Mudar** | Configura para qual Tipo este pode ser mudado (via `F7` na tela de Movimentos) e **como** essa mudança ocorre: `Transformar` (mesmo movimento muda de Tipo, sem exigir permissão de estorno) ou `Duplicar` (gera novo movimento, o anterior fica em status `VINCULADO` e forma pilha). Típico no ciclo `ORÇAMENTO → PEDIDO → VENDA`. |
 | **Agrupar** | Regras de agrupamento de movimentos (juntar vários pedidos em uma única nota, por exemplo). |
 
 ---

--- a/Movimentacao/TiposDeMovimento/faq.md
+++ b/Movimentacao/TiposDeMovimento/faq.md
@@ -150,6 +150,15 @@ A flag `Quitar Crédito Automaticamente` só é válida em Tipos exclusivos da a
 **O que a flag `PDV` faz exatamente?**
 Marca o Tipo como **exclusivo da aplicação PDV** (frente de caixa — um sistema à parte do ponto de vista do usuário, embora seja o mesmo Sol.NET compilado em modo PDV). Tipos com `PDV` marcado **não aparecem** no combo `Tipo` das telas `Movimentos de Compras/Vendas/Outros` (`201/202/203`). Ela **não** ativa nenhum "modo PDV" nessas telas — é puramente um filtro de visibilidade.
 
+### Mudar — Transformar vs Duplicar
+
+**Quando usar `Transformar` vs `Duplicar` na configuração de Mudar?**
+
+- Use **Transformar** quando o cliente prefere **simplicidade** — o movimento vira o próximo Tipo no ciclo sem deixar rastro de cada etapa. O `ID` interno é preservado. Vantagem operacional importante: permite que o usuário avance o ciclo (`ORÇAMENTO → PEDIDO → VENDA`, p.ex.) mesmo **sem permissão de estorno**, porque tecnicamente o movimento não é estornado e re-lançado, é só reconfigurado.
+- Use **Duplicar** quando o cliente quer **rastreabilidade** — cada etapa do ciclo (orçamento, pedido, faturamento) fica como movimento separado e auditável. O Sol.NET marca o anterior como `VINCULADO` e congela ele até o subsequente ser cancelado, garantindo que a pilha não fique inconsistente. Visualize a pilha pela sub-aba `Vínculos` na tela de Movimentos.
+
+A decisão fica no cadastro do Tipo de **destino** da mudança. O operador da tela de Movimentos não escolhe o modo no momento do `F7` — ele recebe o resultado do que o Tipo dita.
+
 ### Clonagem e Histórico
 
 **Posso editar um Tipo já usado em movimentos antigos sem afetar o histórico?**

--- a/Movimentacao/TiposDeMovimento/faq.md
+++ b/Movimentacao/TiposDeMovimento/faq.md
@@ -144,8 +144,11 @@ Algumas opções desta tela ficam bloqueadas quando a empresa tem flags globais 
 **Quando usar `Devolução Crédito`?**
 Quando a devolução deve **gerar um crédito** ao cliente em vez de devolver dinheiro/refazer pagamento. O crédito fica disponível na pessoa e pode ser usado para abater compras futuras.
 
-**Devolução de PDV está reclamando que `Quitar Crédito Automaticamente` exige PDV.**
-A flag `Quitar Crédito Automaticamente` só é válida em tipos com a flag PDV marcada. Se o tipo não é PDV, desligue `Quitar Crédito Automaticamente` ou marque `PDV`.
+**`Quitar Crédito Automaticamente` está reclamando que exige `PDV`.**
+A flag `Quitar Crédito Automaticamente` só é válida em Tipos exclusivos da aplicação PDV (frente de caixa). Se este Tipo é operado pela retaguarda (telas `201/202/203`), desligue `Quitar Crédito Automaticamente`. Se realmente é um Tipo do PDV, marque `PDV` — ciente de que o Tipo deixará de aparecer no combo das telas de retaguarda.
+
+**O que a flag `PDV` faz exatamente?**
+Marca o Tipo como **exclusivo da aplicação PDV** (frente de caixa — um sistema à parte do ponto de vista do usuário, embora seja o mesmo Sol.NET compilado em modo PDV). Tipos com `PDV` marcado **não aparecem** no combo `Tipo` das telas `Movimentos de Compras/Vendas/Outros` (`201/202/203`). Ela **não** ativa nenhum "modo PDV" nessas telas — é puramente um filtro de visibilidade.
 
 ### Clonagem e Histórico
 

--- a/TESTE_MERMAID.md
+++ b/TESTE_MERMAID.md
@@ -78,14 +78,18 @@ Diagramas em validação antes de irem pros docs finais (PR #36, conteúdo paral
 
 ### Rascunho 1 — Ciclo de vida de um Movimento
 
-Setas sólidas = transição de estado. Setas pontilhadas = operação que gera artefato sem mudar o estado do movimento.
+Setas sólidas = transição de estado. Setas pontilhadas = operação que gera artefato sem mudar o estado do movimento. O losango decisão do `F7 Mudar` ramifica conforme o Tipo de destino esteja configurado como `Transformar` (mesmo ID muda de Tipo) ou `Duplicar` (novo movimento criado, original vira `VINCULADO`).
 
 ```mermaid
 flowchart TD
   E[Em edição] -->|Gravar| L[Lançado]
   L -->|F6 Finalizar| F[Finalizado]
-  L -->|F7 Mudar| M[Novo movimento<br/>com outro Tipo]
-  F -->|F7 Mudar| M
+  L -->|F7 Mudar| D{Modo configurado<br/>no Tipo?}
+  F -->|F7 Mudar| D
+  D -->|Transformar| F
+  D -->|Duplicar| N[Novo movimento<br/>com outro Tipo]
+  D -->|Duplicar| V[VINCULADO<br/>original congelado]
+  N -. pilha .-> V
   F -->|F11 Estornar| X[Estornado]
   F -. F8 Quitar .-> Q[(Quita títulos)]
   F -. F10 NF-e .-> NF[(Emite documento fiscal)]

--- a/TESTE_MERMAID.md
+++ b/TESTE_MERMAID.md
@@ -72,6 +72,53 @@ stateDiagram-v2
     FINALIZADO --> [*]
 ```
 
+## 🧰 Leva-piloto de diagramas — rascunhos a validar
+
+Diagramas em validação antes de irem pros docs finais (PR #36, conteúdo paralelo à reescrita do trio Movimentos 201/202/203).
+
+### Rascunho 1 — Ciclo de vida de um Movimento
+
+Setas sólidas = transição de estado. Setas pontilhadas = operação que gera artefato sem mudar o estado do movimento.
+
+```mermaid
+flowchart TD
+  E[Em edição] -->|Gravar| L[Lançado]
+  L -->|F6 Finalizar| F[Finalizado]
+  L -->|F7 Mudar| M[Novo movimento<br/>com outro Tipo]
+  F -->|F7 Mudar| M
+  F -->|F11 Estornar| X[Estornado]
+  F -. F8 Quitar .-> Q[(Quita títulos)]
+  F -. F10 NF-e .-> NF[(Emite documento fiscal)]
+  F -. F9 Imprimir .-> P[(Impressão)]
+```
+
+### Rascunho 2 — Ciclo Orçamento → Pedido → NFC-e
+
+```mermaid
+flowchart TD
+  O["ORÇAMENTO<br/>(sem efeito no estoque<br/>nem no financeiro)"] -->|F7 Mudar| P["PEDIDO<br/>(estoque baixa<br/>financeiro aberto)"]
+  P -->|F7 Mudar| N["NFC-E CUPOM FISCAL<br/>(quitação dispara<br/>emissão fiscal inicia)"]
+```
+
+### Rascunho 3 — Fluxo de Produção
+
+```mermaid
+flowchart TD
+  R[Fórmula cadastrada<br/>na tela 143] -. pré-requisito .-> F[Nova Produção<br/>na tela 144]
+  F -->|Iniciar Produção| I[Status: Iniciada]
+  I -->|Finalizar Produção| OK[Status: Finalizada]
+  I -->|Cancelar| C[Status: Cancelada]
+  OK --> M1[Movimento de saída<br/>dos ingredientes]
+  OK --> M2[Movimento de entrada<br/>do produto acabado]
+  OK --> M3[Movimento de perda<br/>quando a fórmula tem perdas]
+  M1 --> T{Vão para a tela<br/>operacional do Tipo<br/>de Movimento configurado}
+  M2 --> T
+  M3 --> T
+  T --> T1[201 Compras]
+  T --> T2[202 Vendas]
+  T --> T3[203 Outros]
+```
+
 ## ✅ Verificação
 
 Se você consegue ver os diagramas renderizados acima (e não apenas o código), então o suporte Mermaid está funcionando corretamente! 🎉

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -473,6 +473,19 @@
             <summary class="sn-sidebar__group-summary">📦 Movimentação</summary>
             <ul class="sn-sidebar__items">
               <li><a href="{{ '/Movimentacao/' | relative_url }}">Visão geral</a></li>
+              <li>
+                <details class="sn-sidebar__subgroup" data-sn-subgroup="movimentos">
+                  <summary class="sn-sidebar__subgroup-summary">Movimentos</summary>
+                  <ul class="sn-sidebar__subitems">
+                    <li><a href="{{ '/Movimentacao/Movimentos/' | relative_url }}">Visão geral</a></li>
+                    <li><a href="{{ '/Movimentacao/Movimentos/documentacao_movimentos/' | relative_url }}">Movimentos — referência</a></li>
+                    <li><a href="{{ '/Movimentacao/Movimentos/movimentos_de_compras/' | relative_url }}">Movimentos de Compras</a></li>
+                    <li><a href="{{ '/Movimentacao/Movimentos/movimentos_de_vendas/' | relative_url }}">Movimentos de Vendas</a></li>
+                    <li><a href="{{ '/Movimentacao/Movimentos/outros_movimentos/' | relative_url }}">Outros Movimentos</a></li>
+                    <li><a href="{{ '/Movimentacao/Movimentos/faq/' | relative_url }}">FAQ</a></li>
+                  </ul>
+                </details>
+              </li>
               <li><a href="{{ '/Movimentacao/documentacao_locais_de_estoque/' | relative_url }}">Locais de Estoque</a></li>
               <li><a href="{{ '/Movimentacao/documentacao_transacoes_de_estoque/' | relative_url }}">Transações de Estoque</a></li>
               <li>


### PR DESCRIPTION
## Resumo

Reescrita do trio operacional **Movimentos de Compras (`201`) / Movimentos de Vendas (`202`) / Outros Movimentos (`203`)** no padrão estabelecido em [Tipos de Movimento](https://github.com/hetosoft/documentacao-solnet/tree/main/Movimentacao/TiposDeMovimento). Continuação direta do [PR #35](https://github.com/hetosoft/documentacao-solnet/pull/35).

### Achado-chave

Os três `NOME_FORMULARIO` no banco (`CompraFrmMovimentacao`, `VendaFrmMovimentacao`, `OutrosFrmMovimentacao`) **apontam para o mesmo form Delphi físico** — `uFrmMovimentacao.pas` (~3MB, 81.915 linhas, 1.050 procedures). O modo é decidido por um parâmetro de tipo (0=Venda / 1=Compra / 2=Outros) no dispatcher (`Sol.Net_ReportServer/uFuncoesGerais.pas:3404-3442`). Implicação: as três telas compartilham >90% do comportamento.

### Estrutura criada

```
Movimentacao/Movimentos/
  README.md                       índice da subpasta
  documentacao_movimentos.md      referência compartilhada (mapa do formulário, fluxos, atalhos, validações)
  movimentos_de_compras.md        perfil 201 (CFOPs entrada, atualização de custo, importação XML)
  movimentos_de_vendas.md         perfil 202 (Tipos acessados por vendedores, ciclo Orçamento→Pedido→NFC-e)
  outros_movimentos.md            perfil 203 (transferências entre filiais, devoluções de venda, ajustes, perdas, produção)
  faq.md                          FAQ com validações ao salvar/finalizar/emitir fiscal
```

### Outras mudanças

- **Sidebar** (`_layouts/default.html`): novo subgrupo expansível `Movimentos` aninhado em `Movimentação`, mesmo padrão CSS de `TiposDeMovimento`.
- **`Movimentacao/README.md`**: passa de esqueleto "em reescrita" para índice agrupado por papel (Operação / Configuração / Consulta / Auxiliares).

### Atalhos validados

`F6` Finalizar · `F7` Mudar · `F8` Quitar · `F9` Imprimir · `F10` NF-e · `F11` Estornar (todos confirmados em `FormKeyDown` do `.pas`).

### Conceitos corrigidos durante o PR

- **PDV é aplicação à parte.** Tipos de Movimento com flag `PDV` marcada não aparecem em `201/202/203` — são exclusivos da aplicação PDV (frente de caixa), que será documentada em outra seção. Doc de `Movimentos/` e `TiposDeMovimento/` ajustadas para refletir isso.
- **Classificação 201/202/203 segue o operador, não só o Comportamento.** `202` Vendas lista só Tipos acessados por vendedores; devolução de venda e transferência entre filiais ficam em `203`, não em `202`.
- **Nomes reais das sub-abas**: a aba financeira do form é `Financeiro` (com sub-abas Contas / Parcelas / Rateio / Imagens / Forma de Pagamento), não "Vencimento" — a aba `Vencimento` existe mas é controle de **lote/data de validade dos produtos**. Outros Captions corrigidos: `Descontos/Outras Despesas` (não "Outros Valores"), `Tributação` (não "Observações dos Itens"), `ICMS/ST/IPI Livre`, `Pontos`, `Estoque do Produto`.

### Regras invioláveis respeitadas

- Tela `53` **não mencionada**.
- Telas `64` (Pedido de Compra), `79` (Ajuste), `144` (Produção) descritas como **disparadoras** de movimentos em `201/202/203`, não como armazenadoras.
- Sempre `grid`, nunca `grade`.
- Subpasta com submódulo expansível na sidebar (padrão TiposDeMovimento).
- Footer `Versão 5.0`.
- Atalhos só os validados em código.

## Conteúdo paralelo: leva-piloto de diagramas Mermaid

Aproveitando o PR, foi incluída uma **leva-piloto de 3 diagramas Mermaid** (`flowchart TD`) em pontos onde o texto sequencial estava denso. Pioneirismo controlado: o Financeiro não usa Mermaid, então não há precedente de padrão a seguir.

1. **Ciclo de vida de um Movimento** — `Movimentacao/Movimentos/documentacao_movimentos.md`, no topo de `Fluxos principais`. Estados sólidos × operações secundárias com seta pontilhada (F8 Quitar, F9 Imprimir, F10 NF-e não mudam estado).
2. **Ciclo Orçamento → Pedido → NFC-e** — `Movimentacao/Movimentos/movimentos_de_vendas.md`, no exemplo recém-reescrito. Visualiza onde estoque baixa, financeiro nasce, quitação dispara, fiscal é emitido.
3. **Fluxo de Produção** — `Movimentacao/Producao/README.md`, após o parágrafo de abertura. Fórmula 143 → Produção 144 → 3 movimentos automáticos → tela operacional conforme Tipo (pode ser qualquer das 3 telas, não necessariamente `203`).

`TESTE_MERMAID.md` mantém os 3 rascunhos como paraquedas — se algum diagrama falhar no Pages, dá pra iterar nele sem mexer nos docs publicados.

## Test plan

- [ ] Após merge, GitHub Pages renderiza `https://hetosoft.github.io/documentacao-solnet/Movimentacao/Movimentos/` e cada perfil sem 404
- [ ] Sidebar mostra subgrupo `Movimentos` expansível em paralelo a `Tipos de Movimento`
- [ ] Links relativos (`../TiposDeMovimento/`, `../Producao/`, `../documentacao_*.md`) resolvem
- [ ] Subgrupo expansível abre/fecha independente do pai `Movimentação`
- [ ] **Diagrama 1** renderiza em `/Movimentacao/Movimentos/documentacao_movimentos/` com setas pontilhadas exibindo labels `F8 Quitar` / `F9 Imprimir` / `F10 NF-e`
- [ ] **Diagrama 2** renderiza em `/Movimentacao/Movimentos/movimentos_de_vendas/` (3 nós, 2 setas com label `F7 Mudar`)
- [ ] **Diagrama 3** renderiza em `/Movimentacao/Producao/` (Fórmula → Produção → 3 movimentos → 3 telas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)