### PR TITLE
docs(fiscal): documentação de Importar XML NF-e e Conferência de XML

### DIFF
--- a/Fiscal/README.md
+++ b/Fiscal/README.md
@@ -62,11 +62,43 @@ Perguntas comuns sobre conceitos, operação, NSU e vínculo com a Movimentaçã
 
 ---
 
+### 📥 Importar XML NF-e
+
+#### 📖 [Documentação Importar XML](documentacao_importar_xml.md)
+Como carregar o XML de uma NF-e e transformá-lo em movimento de entrada (ou saída, no caso de emissão própria):
+- Tela `Importar XML NF-e` (código `204`) — consulta e filtros de XMLs carregados
+- Carregamento via arquivo `.xml` e via Manifestação do Destinatário
+- Sub-abas `XML`, `Cabeçalho`, `Itens`, `Financeiro`, `Conferência`
+- Vínculo de itens do XML com o cadastro de produtos (manual, automático e cadastro durante o vínculo)
+- Lançamento na movimentação: `Lançar NF-e`, `Lançar Parcial`, `Lançar Próprio` e `DANFE`
+- Relação com a Manifestação do Destinatário
+
+#### ⚡ [Guia Rápido — Importar XML](guia_rapido_importar_xml.md)
+Cartão de referência para o suporte:
+- Checklist da rotina padrão de importação
+- Os três botões de lançamento e quando usar cada um
+- Tabelas de status, conferência e financeiro
+- Mensagens de erro mais comuns e como resolver
+- Combinações úteis de filtros
+
+#### ❓ [FAQ — Importar XML](faq_importar_xml.md)
+Perguntas comuns sobre carregamento, vínculo de itens, lançamento e relação com Manifestação.
+
+#### 🔬 [Conferência de XML](documentacao_conferencia_xml.md)
+Fluxo dedicado da conferência física da mercadoria:
+- Habilitação por loja no `Cadastro de Empresas`
+- Estados da conferência (`Não Conferido`, `Em Andamento`, `Sem Divergência`, `Com Divergência`)
+- Aba `Conferência` dentro do `Importar XML` e o que o conferente faz
+- Reabertura de conferências finalizadas (permissão especial)
+- Como a conferência interage com `Lançar NF-e` / `Lançar Parcial`
+
+---
+
 ## 🎯 Por Onde Começar
 
-- **👤 Primeira leitura** — abra a [Documentação da Reforma Tributária](documentacao_reforma_tributaria.md) para entender o cronograma fiscal, depois passe pela [Documentação da Manifestação](documentacao_manifestacao_destinatario.md) para a rotina diária.
+- **👤 Primeira leitura** — abra a [Documentação da Reforma Tributária](documentacao_reforma_tributaria.md) para entender o cronograma fiscal, depois passe pela [Documentação da Manifestação](documentacao_manifestacao_destinatario.md) e pela [Documentação Importar XML](documentacao_importar_xml.md) para a rotina diária de entrada de notas.
 - **🔧 Configurador** — foque nas seções de cadastro de NCM e regras tributárias na [Documentação da Reforma Tributária](documentacao_reforma_tributaria.md), e use o [FAQ](faq_reforma_tributaria.md) para casos específicos.
-- **⚡ Operacional / Suporte** — o [Guia Rápido — Manifestação do Destinatário](guia_rapido_manifestacao_destinatario.md) cobre a rotina mais comum no atendimento.
+- **⚡ Operacional / Suporte** — os guias rápidos da [Manifestação do Destinatário](guia_rapido_manifestacao_destinatario.md) e do [Importar XML](guia_rapido_importar_xml.md) cobrem a rotina mais comum no atendimento.
 
 ---
 
@@ -78,5 +110,5 @@ Perguntas comuns sobre conceitos, operação, NSU e vínculo com a Movimentaçã
 ---
 
 **📅 Última atualização**: Maio de 2026  
-**📦 Versão**: 1.1  
+**📦 Versão**: 1.2  
 **🎯 Público-alvo**: Usuários, contadores, configuradores e equipe de suporte Sol.NET

--- a/Fiscal/documentacao_conferencia_xml.md
+++ b/Fiscal/documentacao_conferencia_xml.md
@@ -1,0 +1,249 @@
+# 📄 Conferência de XML - Sol.NET
+
+## 🎯 Visão Geral
+
+A **Conferência de XML** é um mecanismo opcional do Sol.NET para **confrontar a mercadoria recebida fisicamente com o que veio no XML do fornecedor** *antes* de a NF-e virar movimento de entrada.
+
+Quando habilitada na loja, a tela [Importar XML NF-e](documentacao_importar_xml.md) (código `204`) ganha uma aba **`Conferência`**, e o grid principal passa a mostrar o `Status Conferência` de cada XML. A conferência funciona como uma **etapa intermediária** entre carregar o XML e clicar em `Lançar NF-e`:
+
+1. XML chega na tela `Importar XML` (manualmente ou via Manifestação do Destinatário).
+2. Conferente físico abre o registro, vai na aba `Conferência` e marca o que efetivamente recebeu (por item).
+3. O Sol.NET classifica como `Sem Divergência` ou `Com Divergência`.
+4. Lançamento na movimentação é feito depois, já ciente do que bate ou não com o XML.
+
+### Para que serve
+
+- ✅ Garantir que a entrada na movimentação só ocorre após conferência física da mercadoria
+- ✅ Detectar divergências de quantidade ou de código entre o XML e o recebido
+- ✅ Bloquear lançamento (ou pelo menos sinalizar) quando o conferente registrar diferença
+- ✅ Auditar quem conferiu cada nota e quando
+- ✅ Servir como base de negociação com fornecedor em caso de falta ou excedente
+
+### Quando o suporte é acionado
+
+- "A aba `Conferência` não aparece" → loja não está com o tipo de conferência habilitado.
+- "Status Conferência ficou em `Em Andamento` para sempre" → conferente não finalizou a conferência; orientar como retomar.
+- "Preciso reabrir a conferência" → conferente terminou mas precisa ajustar; explicar o fluxo de voltar para `Em Andamento`.
+- "Quero saber por que o lançamento da NF-e foi feito sem conferência" → loja não usa o recurso ou foi desabilitado.
+
+---
+
+## 🚪 Como habilitar a conferência
+
+A conferência é **configurada por loja** (não é um parâmetro global do sistema). A configuração fica no `Cadastro de Empresas`:
+
+1. Pressione F1 e abra o `Cadastro de Empresas` (código `100`).
+2. Localize a loja desejada no grid de busca.
+3. Abra o registro e localize o campo **`Tipo Conferência XML`** (ou rótulo equivalente).
+4. Habilite e grave.
+
+> ⚠️ **Acesso de suporte necessário:** alterações no `Cadastro de Empresas` requerem permissão de acesso de suporte. Entre em contato com o suporte Hetosoft antes de realizar qualquer modificação nesta tela.
+
+A partir da habilitação:
+
+- Todo XML carregado na tela `Importar XML` para essa loja passa a exigir conferência antes do lançamento.
+- A aba `Conferência` aparece na tela `204` para registros dessa loja.
+- O grid principal da tela `204` mostra a coluna `Status Conferência` preenchida.
+
+Para **desabilitar**, basta desmarcar o campo no `Cadastro de Empresas`. XMLs já em conferência permanecem com seu status registrado, mas novos XMLs daquela loja passam direto.
+
+---
+
+## 🔍 Os estados da conferência
+
+A conferência tem **dois campos** que andam juntos no grid e nos relatórios.
+
+### `Status Conferência` (de andamento)
+
+Indica em que ponto do fluxo o XML está.
+
+| Texto exibido | Significa | O que pode fazer |
+|---------------|-----------|------------------|
+| `NÃO CONFERIDO` | Conferência não iniciada. | Abrir o registro e iniciar. |
+| `EM ANDAMENTO` | Conferência aberta, alguns itens já tratados, mas não finalizada. | Retomar e concluir. |
+| `FINALIZADA SEM DIVERGÊNCIA` | Conferente concluiu e tudo bateu com o XML. | Pode lançar a NF-e. |
+| `FINALIZADA COM DIVERGÊNCIA` | Conferente concluiu e marcou pelo menos um item como divergente. | Avaliar antes de lançar; possivelmente usar `Lançar Parcial`. |
+
+### Indicador no grid
+
+Na grid principal da tela `204`, a coluna `Status Conferência` muda de cor conforme o estado — divergências são sinalizadas em vermelho/destaque, conferências finalizadas sem divergência em verde. Isso ajuda a varrer rapidamente o que precisa de atenção.
+
+---
+
+## 🧭 A aba `Conferência` dentro do `Importar XML`
+
+A aba **`Conferência`** só fica visível quando a loja tem o recurso habilitado e o XML está aberto. Ela exibe um grid (`dbgItensConferencia`) com **uma linha por item da NF-e**, focado no que o conferente precisa marcar.
+
+### Colunas do grid
+
+| Coluna | Para que serve |
+|--------|----------------|
+| `Sel.` | Marcação manual de itens (uso operacional). |
+| `Nº` | Número sequencial do item dentro da NF-e. |
+| `Cód. Forn.` | Código do produto no fornecedor (vem do XML). |
+| `EAN Forn.` | EAN do produto no fornecedor. |
+| `Produto do Fornecedor` | Descrição como aparece na nota do fornecedor. |
+| `Código` | Código do produto **no cadastro do Sol.NET** (após vínculo). |
+| `Conf.` | Marcação de conferido — alimentada pela conferência física. |
+| `Descrição` | Descrição do produto no cadastro. |
+| `Quantidade` (várias colunas: `Q.De`, `Q.Na`, `Quant.`) | Quantidades e suas conversões de unidade. |
+| `Vl. Unitário`, `Custo I. Nota`, `Custo I. Atual`, `Dif. Custo %` | Análise de custo entre o que o XML traz e o cadastro. |
+| `Vl. Total`, `Bs. ICMS`, `Vl. ICMS`, `Bs. ICMS ST`, `Vl. ICMS ST`, `Vl. IPI` | Valores fiscais para conferência. |
+
+> 💡 As colunas de tributos servem mais para auditoria que para conferência física — o foco da operação é nas colunas de **quantidade** e **código**.
+
+### O que o conferente faz
+
+Em geral o fluxo manual é:
+
+1. Item a item, comparar o que está no XML com a mercadoria física à frente.
+2. Marcar a coluna `Conf.` quando o item bate (quantidade e identificação).
+3. Quando há diferença (falta, excesso, item diferente), **registrar a divergência** — o sistema marca `TP_DIVERGENCIA = 1` na linha.
+4. No final, finalizar a conferência (botão correspondente na tela, ver próxima seção).
+
+> ⚠️ Telas auxiliares de leitor de código de barras podem ser usadas para alimentar essa conferência automaticamente — o resultado, porém, chega ao mesmo grid e segue as mesmas regras.
+
+---
+
+## 🚦 O ciclo da conferência
+
+O fluxo completo, da chegada da mercadoria ao lançamento, fica assim:
+
+```
+[XML carregado] 
+       │ Status Conferência: NÃO CONFERIDO
+       ▼
+[Conferente abre o registro]
+       │ Status Conferência: EM ANDAMENTO
+       ▼
+[Marca/desmarca itens, registra divergências]
+       │
+       ▼
+[Finaliza a conferência]
+       │ STATUS_CONFERENCIA_ANDAMENTO = 2
+       │  ├── Sem divergência → FINALIZADA SEM DIVERGÊNCIA
+       │  └── Com divergência → FINALIZADA COM DIVERGÊNCIA
+       ▼
+[Operador decide lançar a NF-e]
+       └── Lançar NF-e / Lançar Parcial conforme o caso
+```
+
+### Reabrir uma conferência finalizada
+
+Quando o conferente conclui mas precisa ajustar (item esquecido, divergência registrada errada), é possível **voltar a conferência para `Em Andamento`**:
+
+- A operação exige permissão (consulta interna `375`); usuários sem acesso são bloqueados.
+- O sistema mostra `Conferencia não está finalizada!` se tentar reabrir uma conferência que ainda está em andamento — o objetivo é reabrir uma já finalizada.
+- Ao confirmar a reabertura, o status volta para `EM ANDAMENTO` e a mensagem `Status de Conferencia Alterado para EM ANDAMENTO.` é exibida.
+
+A reabertura é uma exceção operacional — o caminho normal é finalizar uma única vez.
+
+---
+
+## 🔗 Interação com o lançamento da NF-e
+
+O `Status Conferência` **não bloqueia** automaticamente o lançamento da NF-e — o operador tem autonomia para decidir. Mas a informação serve de gate:
+
+| Situação | Recomendação |
+|----------|--------------|
+| `Não Conferido` em loja com conferência habilitada | Pedir conferência antes de lançar. Lançar sem conferir contraria o propósito do recurso. |
+| `Em Andamento` | Conferência incompleta. Concluir primeiro. |
+| `Finalizada Sem Divergência` | Pode lançar com `Lançar NF-e` sem ressalvas. |
+| `Finalizada Com Divergência` | Decidir entre: |
+| | • `Lançar NF-e` — entrar tudo igual ao XML (assume divergência como erro de conferência). |
+| | • `Lançar Parcial` — entrar somente o efetivamente recebido. |
+| | • Não lançar e contatar fornecedor. |
+
+A operação de `Lançar` em si é a mesma descrita em [Importar XML — Lançar a NF-e na movimentação](documentacao_importar_xml.md).
+
+---
+
+## 💡 Exemplos Práticos
+
+### Exemplo 1 — Conferência sem divergência
+
+**Cenário**: chegou um caminhão com 12 caixas conforme NF-e. Cada caixa contém um item que está no XML, na quantidade certa.
+
+1. O XML já está no Sol.NET (importado pela Manifestação ou carregado manualmente).
+2. O conferente abre o registro na tela `204`, vai na aba `Conferência`.
+3. Confere item a item. Tudo bate.
+4. Marca `Conf.` em todos os itens.
+5. Finaliza a conferência. `Status Conferência` vira `FINALIZADA SEM DIVERGÊNCIA`.
+6. O operador (mesmo usuário ou outro) clica em `Lançar NF-e`. Entrada gerada normalmente.
+
+### Exemplo 2 — Conferência com divergência de quantidade
+
+**Cenário**: XML lista 10 unidades de um produto; chegaram apenas 8.
+
+1. Conferente abre o registro, vai na aba `Conferência`.
+2. Confere os itens. No item divergente, registra a quantidade efetiva (8) — o item fica marcado como divergente (`TP_DIVERGENCIA = 1`).
+3. Finaliza a conferência. `Status Conferência` vira `FINALIZADA COM DIVERGÊNCIA` e a coluna no grid principal aparece em destaque.
+4. Operador decide:
+   - **Opção A**: lançar tudo igual ao XML (`Lançar NF-e`) e tratar a falta com o fornecedor depois — gera um excedente fiscal de 2 unidades que precisará de ajuste.
+   - **Opção B**: lançar parcial (`Lançar Parcial`), entrando só as 8 unidades; o XML permanece registrado e a divergência é histórico.
+5. Sempre comunicar o fornecedor para correção (carta de correção, retorno de mercadoria, abatimento).
+
+### Exemplo 3 — Conferência por código diferente
+
+**Cenário**: XML lista o produto X, mas chegou o produto Y (código diferente).
+
+1. Conferente abre a aba `Conferência`.
+2. Marca o item como divergente — o EAN ou código que chegou não bate.
+3. Finaliza a conferência como `Com Divergência`.
+4. Esse caso normalmente **não deve virar movimento** — a mercadoria errada precisa voltar para o fornecedor e uma nota corretiva precisa ser emitida.
+
+### Exemplo 4 — Reabrir conferência por engano
+
+**Cenário**: conferente finalizou a conferência, mas percebeu que esqueceu de marcar um item.
+
+1. Operador com permissão abre o registro pelo grid (estado de visualização).
+2. Aciona a função de reabrir conferência (ver `Reabrir uma conferência finalizada` acima).
+3. Confirma. Status volta para `EM ANDAMENTO`.
+4. Conferente reentra, ajusta, e finaliza de novo.
+
+---
+
+## ❓ FAQ / Problemas Comuns
+
+### ❓ A aba `Conferência` não aparece para mim. Por quê?
+
+A aba só é exibida quando a loja (registro do XML) tem o `Tipo Conferência XML` habilitado no `Cadastro de Empresas`. Verifique a loja do XML aberto e a configuração da loja.
+
+### ❓ Posso usar conferência em uma loja e em outra não?
+
+Sim. A configuração é **por loja**. Lojas onde o recurso não faz sentido (ex.: ponto de venda sem recebimento físico) podem ficar sem.
+
+### ❓ Quem pode finalizar uma conferência? E reabrir?
+
+Qualquer usuário com acesso à tela `Importar XML` pode iniciar e finalizar uma conferência. **Reabrir** uma conferência já finalizada exige permissão específica (controle de acesso interno `375`) — se o usuário não tem, recebe bloqueio de permissão.
+
+### ❓ Conferência finalizada pode ser apagada?
+
+Não. O histórico de conferência fica no registro do XML mesmo após o lançamento da NF-e. É possível reabrir (ver acima) para ajustar antes do lançamento.
+
+### ❓ O sistema bloqueia o lançamento da NF-e se a conferência estiver pendente?
+
+O Sol.NET **não bloqueia automaticamente** — mas o `Status Conferência` no grid e na tela serve de aviso visual. A política de "não lançar sem conferir" é uma regra **operacional** da empresa, não uma restrição do sistema. Se quiser bloqueio rígido, a equipe Hetosoft pode avaliar uma configuração específica.
+
+### ❓ Posso ver quem conferiu cada nota?
+
+Sim. A coluna `Usuário Conferencia` no grid mostra o operador que finalizou a conferência. O carimbo é gravado no momento da finalização.
+
+### ❓ Conferência funciona para NF-e de saída (emissão própria)?
+
+Não no mesmo modelo. A conferência aqui descrita serve para **recebimento de mercadoria** — confronta XML do fornecedor com o que entrou no estoque. Em NF-e própria (saída), a tela `Importar XML` opera com o botão `Lançar Próprio`, sem fluxo de conferência.
+
+---
+
+## 🔗 Documentos relacionados
+
+- [Documentação Importar XML](documentacao_importar_xml.md) — onde a conferência se encaixa
+- [Guia Rápido — Importar XML](guia_rapido_importar_xml.md) — atalhos para suporte
+- [FAQ — Importar XML](faq_importar_xml.md) — perguntas mais frequentes
+- [Manifestação do Destinatário](documentacao_manifestacao_destinatario.md) — porta de entrada dos XMLs
+
+---
+
+**Última atualização**: Maio de 2026  
+**Versão**: 1.0  
+**Público-alvo**: Equipe de suporte Sol.NET, conferentes e administradores de loja

--- a/Fiscal/documentacao_conferencia_xml.md
+++ b/Fiscal/documentacao_conferencia_xml.md
@@ -19,12 +19,12 @@ Quando habilitada na loja, a tela [Importar XML NF-e](documentacao_importar_xml.
 - ✅ Auditar quem conferiu cada nota e quando
 - ✅ Servir como base de negociação com fornecedor em caso de falta ou excedente
 
-### Quando o suporte é acionado
+### Situações comuns no dia a dia
 
-- "A aba `Conferência` não aparece" → loja não está com o tipo de conferência habilitado.
-- "Status Conferência ficou em `Em Andamento` para sempre" → conferente não finalizou a conferência; orientar como retomar.
-- "Preciso reabrir a conferência" → conferente terminou mas precisa ajustar; explicar o fluxo de voltar para `Em Andamento`.
-- "Quero saber por que o lançamento da NF-e foi feito sem conferência" → loja não usa o recurso ou foi desabilitado.
+- A aba `Conferência` não aparece → a loja não está com o tipo de conferência habilitado.
+- `Status Conferência` continua em `Em Andamento` indefinidamente → a conferência foi iniciada mas não foi finalizada; é preciso voltar ao registro e concluir.
+- Necessidade de reabrir uma conferência já finalizada → existe um fluxo controlado por permissão para devolver o status para `Em Andamento`.
+- NF-e foi lançada sem conferência → a loja pode não usar o recurso ou ele foi desabilitado.
 
 ---
 
@@ -238,7 +238,7 @@ Não no mesmo modelo. A conferência aqui descrita serve para **recebimento de m
 ## 🔗 Documentos relacionados
 
 - [Documentação Importar XML](documentacao_importar_xml.md) — onde a conferência se encaixa
-- [Guia Rápido — Importar XML](guia_rapido_importar_xml.md) — atalhos para suporte
+- [Guia Rápido — Importar XML](guia_rapido_importar_xml.md) — cartão de referência rápido
 - [FAQ — Importar XML](faq_importar_xml.md) — perguntas mais frequentes
 - [Manifestação do Destinatário](documentacao_manifestacao_destinatario.md) — porta de entrada dos XMLs
 
@@ -246,4 +246,4 @@ Não no mesmo modelo. A conferência aqui descrita serve para **recebimento de m
 
 **Última atualização**: Maio de 2026  
 **Versão**: 1.0  
-**Público-alvo**: Equipe de suporte Sol.NET, conferentes e administradores de loja
+**Público-alvo**: Conferentes, usuários e administradores de loja do Sol.NET ERP

--- a/Fiscal/documentacao_conferencia_xml.md
+++ b/Fiscal/documentacao_conferencia_xml.md
@@ -32,7 +32,7 @@ Quando habilitada na loja, a tela [Importar XML NF-e](documentacao_importar_xml.
 
 A conferência é **configurada por loja** (não é um parâmetro global do sistema). A configuração fica no `Cadastro de Empresas`:
 
-1. Pressione F1 e abra o `Cadastro de Empresas` (código `100`).
+1. Pressione F1 e abra o `Cadastro de Empresas` (código `1`).
 2. Localize a loja desejada no grid de busca.
 3. Abra o registro e localize o campo **`Tipo Conferência XML`** (ou rótulo equivalente).
 4. Habilite e grave.

--- a/Fiscal/documentacao_conferencia_xml.md
+++ b/Fiscal/documentacao_conferencia_xml.md
@@ -4,12 +4,15 @@
 
 A **Conferência de XML** é um mecanismo opcional do Sol.NET para **confrontar a mercadoria recebida fisicamente com o que veio no XML do fornecedor** *antes* de a NF-e virar movimento de entrada.
 
-Quando habilitada na loja, a tela [Importar XML NF-e](documentacao_importar_xml.md) (código `204`) ganha uma aba **`Conferência`**, e o grid principal passa a mostrar o `Status Conferência` de cada XML. A conferência funciona como uma **etapa intermediária** entre carregar o XML e clicar em `Lançar NF-e`:
+A contagem física **não é feita na tela** `Importar XML NF-e` — ela é registrada pelo conferente no aplicativo **Sol.NET Administrativo** (mobile). A tela `204` apenas **exibe o resultado** da conferência feita no app, na aba `Conferência`, e usa esse resultado para classificar o XML em `Sem Divergência` ou `Com Divergência` antes do lançamento.
 
-1. XML chega na tela `Importar XML` (manualmente ou via Manifestação do Destinatário).
-2. Conferente físico abre o registro, vai na aba `Conferência` e marca o que efetivamente recebeu (por item).
-3. O Sol.NET classifica como `Sem Divergência` ou `Com Divergência`.
-4. Lançamento na movimentação é feito depois, já ciente do que bate ou não com o XML.
+O fluxo de ponta a ponta fica assim:
+
+1. XML chega na tela `Importar XML` (via Manifestação do Destinatário ou arquivo).
+2. **Conferente registra a contagem pelo Sol.NET Administrativo** (etapa externa a esta tela).
+3. A aba `Conferência` da tela `204` passa a refletir o que foi conferido — item a item, com indicação de divergências.
+4. O `Status Conferência` do XML é classificado: `Não Conferido`, `Em Andamento`, `Finalizada Sem Divergência` ou `Finalizada Com Divergência`.
+5. Lançamento na movimentação é feito depois, já ciente do que bate ou não com o XML.
 
 ### Para que serve
 
@@ -57,12 +60,12 @@ A conferência tem **dois campos** que andam juntos no grid e nos relatórios.
 
 Indica em que ponto do fluxo o XML está.
 
-| Texto exibido | Significa | O que pode fazer |
-|---------------|-----------|------------------|
-| `NÃO CONFERIDO` | Conferência não iniciada. | Abrir o registro e iniciar. |
-| `EM ANDAMENTO` | Conferência aberta, alguns itens já tratados, mas não finalizada. | Retomar e concluir. |
-| `FINALIZADA SEM DIVERGÊNCIA` | Conferente concluiu e tudo bateu com o XML. | Pode lançar a NF-e. |
-| `FINALIZADA COM DIVERGÊNCIA` | Conferente concluiu e marcou pelo menos um item como divergente. | Avaliar antes de lançar; possivelmente usar `Lançar Parcial`. |
+| Texto exibido | Significa | Próximo passo no Sol.NET |
+|---------------|-----------|--------------------------|
+| `NÃO CONFERIDO` | A contagem ainda não foi iniciada no Sol.NET Administrativo. | Aguardar a equipe da loja iniciar a conferência pelo app. |
+| `EM ANDAMENTO` | A contagem foi iniciada no app, mas ainda não foi finalizada. | Aguardar a equipe concluir pelo app. |
+| `FINALIZADA SEM DIVERGÊNCIA` | A contagem foi concluída e tudo bateu com o XML. | Pode lançar a NF-e. |
+| `FINALIZADA COM DIVERGÊNCIA` | A contagem foi concluída e pelo menos um item ficou divergente. | Avaliar a aba `Conferência` antes de lançar; possivelmente usar `Lançar Parcial`. |
 
 ### Indicador no grid
 
@@ -72,71 +75,61 @@ Na grid principal da tela `204`, a coluna `Status Conferência` muda de cor conf
 
 ## 🧭 A aba `Conferência` dentro do `Importar XML`
 
-A aba **`Conferência`** só fica visível quando a loja tem o recurso habilitado e o XML está aberto. Ela exibe um grid (`dbgItensConferencia`) com **uma linha por item da NF-e**, focado no que o conferente precisa marcar.
+A aba **`Conferência`** só fica visível quando a loja tem o recurso habilitado e o XML está aberto. Ela exibe um grid com **uma linha por item da NF-e**, mostrando **o que o conferente registrou no Sol.NET Administrativo** — quantidades efetivamente recebidas, código bipado e divergências apuradas.
+
+> ℹ️ A aba é **apenas leitura sobre o resultado da contagem**. Não há marcação ou edição da conferência diretamente nessa tela — a operação acontece toda no app.
 
 ### Colunas do grid
 
 | Coluna | Para que serve |
 |--------|----------------|
-| `Sel.` | Marcação manual de itens (uso operacional). |
+| `Sel.` | Marcação manual para ações em lote (uso operacional). |
 | `Nº` | Número sequencial do item dentro da NF-e. |
 | `Cód. Forn.` | Código do produto no fornecedor (vem do XML). |
 | `EAN Forn.` | EAN do produto no fornecedor. |
 | `Produto do Fornecedor` | Descrição como aparece na nota do fornecedor. |
 | `Código` | Código do produto **no cadastro do Sol.NET** (após vínculo). |
-| `Conf.` | Marcação de conferido — alimentada pela conferência física. |
+| `Conf.` | Indica se o item foi conferido no app. |
 | `Descrição` | Descrição do produto no cadastro. |
-| `Quantidade` (várias colunas: `Q.De`, `Q.Na`, `Quant.`) | Quantidades e suas conversões de unidade. |
+| Quantidade (`Q.De`, `Q.Na`, `Quant.`) | Quantidades do XML e suas conversões de unidade — útil para comparar com o que foi efetivamente contado. |
 | `Vl. Unitário`, `Custo I. Nota`, `Custo I. Atual`, `Dif. Custo %` | Análise de custo entre o que o XML traz e o cadastro. |
-| `Vl. Total`, `Bs. ICMS`, `Vl. ICMS`, `Bs. ICMS ST`, `Vl. ICMS ST`, `Vl. IPI` | Valores fiscais para conferência. |
+| `Vl. Total`, `Bs. ICMS`, `Vl. ICMS`, `Bs. ICMS ST`, `Vl. ICMS ST`, `Vl. IPI` | Valores fiscais para auditoria. |
 
-> 💡 As colunas de tributos servem mais para auditoria que para conferência física — o foco da operação é nas colunas de **quantidade** e **código**.
-
-### O que o conferente faz
-
-Em geral o fluxo manual é:
-
-1. Item a item, comparar o que está no XML com a mercadoria física à frente.
-2. Marcar a coluna `Conf.` quando o item bate (quantidade e identificação).
-3. Quando há diferença (falta, excesso, item diferente), **registrar a divergência** — o sistema marca `TP_DIVERGENCIA = 1` na linha.
-4. No final, finalizar a conferência (botão correspondente na tela, ver próxima seção).
-
-> ⚠️ Telas auxiliares de leitor de código de barras podem ser usadas para alimentar essa conferência automaticamente — o resultado, porém, chega ao mesmo grid e segue as mesmas regras.
+> 💡 As colunas de tributos servem mais para auditoria que para análise da contagem — o foco visual é nas colunas de **quantidade** e **código**, que evidenciam onde houve divergência.
 
 ---
 
 ## 🚦 O ciclo da conferência
 
-O fluxo completo, da chegada da mercadoria ao lançamento, fica assim:
+O fluxo de ponta a ponta, com cada estado e o agente responsável pela transição:
 
+```mermaid
+flowchart TD
+    A([XML chega no Sol.NET<br/>via Manifestação ou arquivo]) --> B[Status: NÃO CONFERIDO]
+    B -->|Conferente inicia contagem<br/>no Sol.NET Administrativo| C[Status: EM ANDAMENTO]
+    C -->|Conferente finaliza<br/>contagem no app| D{Houve<br/>divergência?}
+    D -->|Não| E[Status: FINALIZADA<br/>SEM DIVERGÊNCIA]
+    D -->|Sim| F[Status: FINALIZADA<br/>COM DIVERGÊNCIA]
+    E -->|Operador na tela 204| G[Lançar NF-e]
+    F -->|Operador na tela 204| H{Avaliar<br/>divergência}
+    H -->|Lançar tudo conforme XML| G
+    H -->|Lançar só o recebido| I[Lançar Parcial]
+    H -->|Não lançar| J([Contatar fornecedor])
+    G --> K([NF-e vira movimento<br/>de entrada])
+    I --> K
 ```
-[XML carregado] 
-       │ Status Conferência: NÃO CONFERIDO
-       ▼
-[Conferente abre o registro]
-       │ Status Conferência: EM ANDAMENTO
-       ▼
-[Marca/desmarca itens, registra divergências]
-       │
-       ▼
-[Finaliza a conferência]
-       │ STATUS_CONFERENCIA_ANDAMENTO = 2
-       │  ├── Sem divergência → FINALIZADA SEM DIVERGÊNCIA
-       │  └── Com divergência → FINALIZADA COM DIVERGÊNCIA
-       ▼
-[Operador decide lançar a NF-e]
-       └── Lançar NF-e / Lançar Parcial conforme o caso
-```
+
+A contagem em si (`NÃO CONFERIDO` → `EM ANDAMENTO` → `FINALIZADA`) é toda registrada no **Sol.NET Administrativo**. A tela `Importar XML` (`204`) é onde o operador acompanha o status e decide o lançamento depois que a conferência está finalizada.
 
 ### Reabrir uma conferência finalizada
 
-Quando o conferente conclui mas precisa ajustar (item esquecido, divergência registrada errada), é possível **voltar a conferência para `Em Andamento`**:
+Quando uma contagem é concluída mas precisa ser ajustada (item esquecido, divergência registrada errada), é possível **voltar o status para `Em Andamento`** a partir da própria tela `204`:
 
 - A operação exige permissão (consulta interna `375`); usuários sem acesso são bloqueados.
-- O sistema mostra `Conferencia não está finalizada!` se tentar reabrir uma conferência que ainda está em andamento — o objetivo é reabrir uma já finalizada.
-- Ao confirmar a reabertura, o status volta para `EM ANDAMENTO` e a mensagem `Status de Conferencia Alterado para EM ANDAMENTO.` é exibida.
+- A reabertura **só é permitida se a conferência já estiver finalizada**. Se estiver em andamento, o sistema responde com `Conferencia não está finalizada!`.
+- Ao confirmar, o status volta para `EM ANDAMENTO` e a mensagem `Status de Conferencia Alterado para EM ANDAMENTO.` é exibida. O conferente pode então retomar a contagem pelo app.
 
-A reabertura é uma exceção operacional — o caminho normal é finalizar uma única vez.
+A reabertura é uma exceção operacional — o caminho normal é finalizar uma única vez no app.
 
 ---
 
@@ -165,41 +158,39 @@ A operação de `Lançar` em si é a mesma descrita em [Importar XML — Lançar
 **Cenário**: chegou um caminhão com 12 caixas conforme NF-e. Cada caixa contém um item que está no XML, na quantidade certa.
 
 1. O XML já está no Sol.NET (importado pela Manifestação ou carregado manualmente).
-2. O conferente abre o registro na tela `204`, vai na aba `Conferência`.
-3. Confere item a item. Tudo bate.
-4. Marca `Conf.` em todos os itens.
-5. Finaliza a conferência. `Status Conferência` vira `FINALIZADA SEM DIVERGÊNCIA`.
-6. O operador (mesmo usuário ou outro) clica em `Lançar NF-e`. Entrada gerada normalmente.
+2. A equipe da loja faz a contagem pelo **Sol.NET Administrativo** e finaliza a conferência. Tudo bate.
+3. Na tela `204`, o `Status Conferência` aparece como `FINALIZADA SEM DIVERGÊNCIA`.
+4. O operador abre o registro, confere visualmente a aba `Conferência` e clica em `Lançar NF-e`. Entrada gerada normalmente.
 
 ### Exemplo 2 — Conferência com divergência de quantidade
 
 **Cenário**: XML lista 10 unidades de um produto; chegaram apenas 8.
 
-1. Conferente abre o registro, vai na aba `Conferência`.
-2. Confere os itens. No item divergente, registra a quantidade efetiva (8) — o item fica marcado como divergente (`TP_DIVERGENCIA = 1`).
-3. Finaliza a conferência. `Status Conferência` vira `FINALIZADA COM DIVERGÊNCIA` e a coluna no grid principal aparece em destaque.
-4. Operador decide:
+1. A contagem é feita pelo **Sol.NET Administrativo**. O conferente registra a quantidade efetiva (8) — o item fica marcado como divergente.
+2. Ao finalizar a contagem no app, o `Status Conferência` da nota na tela `204` muda para `FINALIZADA COM DIVERGÊNCIA` e a coluna no grid principal aparece em destaque.
+3. Na tela `204`, o operador abre o registro e vai na aba `Conferência` para ver qual item divergiu e em que quantidade.
+4. O operador decide:
    - **Opção A**: lançar tudo igual ao XML (`Lançar NF-e`) e tratar a falta com o fornecedor depois — gera um excedente fiscal de 2 unidades que precisará de ajuste.
-   - **Opção B**: lançar parcial (`Lançar Parcial`), entrando só as 8 unidades; o XML permanece registrado e a divergência é histórico.
+   - **Opção B**: lançar parcial (`Lançar Parcial`), entrando só as 8 unidades; o XML permanece registrado e a divergência fica como histórico.
 5. Sempre comunicar o fornecedor para correção (carta de correção, retorno de mercadoria, abatimento).
 
 ### Exemplo 3 — Conferência por código diferente
 
 **Cenário**: XML lista o produto X, mas chegou o produto Y (código diferente).
 
-1. Conferente abre a aba `Conferência`.
-2. Marca o item como divergente — o EAN ou código que chegou não bate.
-3. Finaliza a conferência como `Com Divergência`.
+1. Durante a contagem no app, o EAN bipado não bate com o item do XML — o app registra divergência de identificação.
+2. Conferência é finalizada como `FINALIZADA COM DIVERGÊNCIA`.
+3. Na tela `204`, o operador vê a divergência na aba `Conferência` (códigos não casaram).
 4. Esse caso normalmente **não deve virar movimento** — a mercadoria errada precisa voltar para o fornecedor e uma nota corretiva precisa ser emitida.
 
 ### Exemplo 4 — Reabrir conferência por engano
 
-**Cenário**: conferente finalizou a conferência, mas percebeu que esqueceu de marcar um item.
+**Cenário**: a conferência foi finalizada pelo app, mas a equipe percebeu que um item foi contado errado.
 
-1. Operador com permissão abre o registro pelo grid (estado de visualização).
+1. Operador com permissão abre o registro na tela `204` (modo visualização).
 2. Aciona a função de reabrir conferência (ver `Reabrir uma conferência finalizada` acima).
 3. Confirma. Status volta para `EM ANDAMENTO`.
-4. Conferente reentra, ajusta, e finaliza de novo.
+4. A equipe retoma a contagem no Sol.NET Administrativo e finaliza novamente.
 
 ---
 
@@ -213,9 +204,13 @@ A aba só é exibida quando a loja (registro do XML) tem o `Tipo Conferência XM
 
 Sim. A configuração é **por loja**. Lojas onde o recurso não faz sentido (ex.: ponto de venda sem recebimento físico) podem ficar sem.
 
-### ❓ Quem pode finalizar uma conferência? E reabrir?
+### ❓ Quem inicia e finaliza a contagem?
 
-Qualquer usuário com acesso à tela `Importar XML` pode iniciar e finalizar uma conferência. **Reabrir** uma conferência já finalizada exige permissão específica (controle de acesso interno `375`) — se o usuário não tem, recebe bloqueio de permissão.
+A contagem é feita pela equipe da loja no aplicativo **Sol.NET Administrativo**. Não há ação de iniciar/finalizar conferência na tela `204` — a tela apenas reflete o status atual da contagem.
+
+### ❓ E para reabrir uma conferência finalizada?
+
+A **reabertura** é a única ação relacionada à conferência feita na tela `204` (não no app). Exige permissão específica (controle de acesso interno `375`) — usuários sem esse acesso recebem bloqueio de permissão. Após reabrir, o status volta para `EM ANDAMENTO` e a equipe retoma a contagem no Sol.NET Administrativo.
 
 ### ❓ Conferência finalizada pode ser apagada?
 
@@ -223,11 +218,11 @@ Não. O histórico de conferência fica no registro do XML mesmo após o lançam
 
 ### ❓ O sistema bloqueia o lançamento da NF-e se a conferência estiver pendente?
 
-O Sol.NET **não bloqueia automaticamente** — mas o `Status Conferência` no grid e na tela serve de aviso visual. A política de "não lançar sem conferir" é uma regra **operacional** da empresa, não uma restrição do sistema. Se quiser bloqueio rígido, a equipe Hetosoft pode avaliar uma configuração específica.
+O Sol.NET **não bloqueia automaticamente** — mas o `Status Conferência` no grid e na tela serve de aviso visual. A política de "não lançar sem conferir" é uma regra **operacional** da empresa, não uma restrição do sistema.
 
 ### ❓ Posso ver quem conferiu cada nota?
 
-Sim. A coluna `Usuário Conferencia` no grid mostra o operador que finalizou a conferência. O carimbo é gravado no momento da finalização.
+Sim. A coluna `Usuário Conferencia` no grid mostra o usuário que finalizou a contagem no app. O carimbo é gravado no momento da finalização.
 
 ### ❓ Conferência funciona para NF-e de saída (emissão própria)?
 

--- a/Fiscal/documentacao_importar_xml.md
+++ b/Fiscal/documentacao_importar_xml.md
@@ -21,12 +21,12 @@ A tela também mantém o **histórico de todos os XMLs já carregados**, com fil
 - ✅ Lançar **parcialmente** uma NF-e quando apenas parte da mercadoria foi recebida
 - ✅ Registrar a saída de uma NF-e **emitida pela própria empresa** que precisa virar movimento
 
-### Quando o suporte é acionado
+### Situações comuns no dia a dia
 
-- "Aparece *Chave de Acesso já Cadastrada*" → mesma NF-e foi carregada duas vezes; orientar como localizar o registro anterior.
-- "Aparece *( ... ) NÃO É SUA EMPRESA*" → o CNPJ do destinatário no XML não bate com nenhuma loja do Sol.NET; orientar conferência da loja ou da nota.
-- "Não consigo vincular o produto" → o item ainda não tem código do fornecedor cadastrado; explicar o duplo clique no item.
-- "Lancei a NF-e mas o financeiro não veio" → o lançamento de duplicatas é controlado por configuração; verificar se a NF-e tem parcelas no XML e se o financeiro foi gerado.
+- Mensagem `Chave de Acesso já Cadastrada` → a mesma NF-e já foi carregada antes; é preciso localizar o registro existente no grid em vez de carregar de novo.
+- Mensagem `( ... ) NÃO É SUA EMPRESA` → o CNPJ do destinatário no XML não bate com nenhuma loja cadastrada; conferir se a NF-e foi emitida para o CNPJ correto.
+- Item da nota fica sem vínculo no grid → ainda não há código de fornecedor cadastrado para esse produto; duplo clique no item resolve, vinculando ou cadastrando o produto.
+- NF-e foi lançada mas o financeiro não apareceu → o XML pode não ter trazido as parcelas (NF-e à vista), ou as parcelas precisam ser conferidas na aba `Financeiro` antes do lançamento.
 
 ---
 
@@ -154,7 +154,7 @@ Lista as **parcelas / duplicatas** trazidas do XML, com `Número`, `Vencimento` 
 
 ## 🛒 Vinculando itens do XML ao cadastro de produtos
 
-Esta é a parte que mais consome tempo no dia a dia e onde o suporte mais é acionado. Cada linha da aba `Itens` representa um produto no XML do fornecedor — e cada uma precisa "casar" com um produto do cadastro **antes** da NF-e poder ser lançada como movimento.
+Esta é a parte que mais consome tempo no dia a dia. Cada linha da aba `Itens` representa um produto no XML do fornecedor — e cada uma precisa "casar" com um produto do cadastro **antes** da NF-e poder ser lançada como movimento.
 
 ### Como o Sol.NET tenta vincular automaticamente
 
@@ -316,4 +316,4 @@ A lista completa está em [FAQ — Importar XML](faq_importar_xml.md). Os mais f
 
 **Última atualização**: Maio de 2026  
 **Versão**: 1.0  
-**Público-alvo**: Equipe de suporte Sol.NET, usuários operacionais e administradores
+**Público-alvo**: Usuários e administradores do Sol.NET ERP

--- a/Fiscal/documentacao_importar_xml.md
+++ b/Fiscal/documentacao_importar_xml.md
@@ -148,7 +148,7 @@ Dentro de `Itens` há ainda duas sub-abas:
 Lista as **parcelas / duplicatas** trazidas do XML, com `Número`, `Vencimento` e `Valor`. Esse grid alimenta a geração de contas a pagar no momento do lançamento da NF-e.
 
 ### Aba `Conferência`
-**Visível apenas quando a empresa tem o tipo de conferência XML habilitado** no `Cadastro de Empresas`. É onde o conferente físico marca o que foi efetivamente recebido. Veja o documento dedicado: [Conferência de XML](documentacao_conferencia_xml.md).
+**Visível apenas quando a empresa tem o tipo de conferência XML habilitado** no `Cadastro de Empresas`. Mostra o resultado da contagem física da mercadoria, feita pelo app **Sol.NET Administrativo** — é uma visão de leitura, não há marcação nesta tela. Veja o documento dedicado: [Conferência de XML](documentacao_conferencia_xml.md).
 
 ---
 

--- a/Fiscal/documentacao_importar_xml.md
+++ b/Fiscal/documentacao_importar_xml.md
@@ -177,7 +177,7 @@ Sempre que uma das condições abaixo é verdadeira, o vínculo automático falh
 Nesses casos, a coluna `Descrição` do item aparece em branco. O usuário precisa **abrir o item e fazer a vinculação manual**:
 
 1. **Duplo clique** sobre a linha do item (ou pressione Enter sobre ela).
-2. A tela `Cadastro de Produtos` (código `40` na pesquisa F1) abre **em modo pesquisa**, já filtrada para mostrar produtos. A descrição que aparece no topo é o nome do produto **no fornecedor** (o que veio no XML), para ajudar a identificar.
+2. A tela `Cadastro de Produtos` (código `32` na pesquisa F1) abre **em modo pesquisa**, já filtrada para mostrar produtos. A descrição que aparece no topo é o nome do produto **no fornecedor** (o que veio no XML), para ajudar a identificar.
 3. Localize o produto correspondente no cadastro e confirme.
 4. O Sol.NET grava o vínculo: a partir daí, **qualquer próxima compra desse mesmo produto com esse fornecedor é vinculada automaticamente** (pelo mesmo `Cód. Forn.`).
 
@@ -216,7 +216,7 @@ Depois que **todos os itens estão vinculados** e o cabeçalho está correto, o 
 Para a maioria absoluta dos casos, este é o botão a usar.
 
 - **Quando usar**: NF-e de **entrada** vinda de fornecedor (mercadoria recebida da forma como a nota descreve, parcelas a pagar como vieram no XML).
-- **O que acontece**: o Sol.NET abre a tela `Movimentos de Entrada` (código `203` na pesquisa F1) já preenchida com cabeçalho, itens, tributos e financeiro do XML. O usuário ajusta o que for necessário (tipo de movimento, conta de financeiro, observações) e grava — gerando estoque e contas a pagar.
+- **O que acontece**: o Sol.NET abre a tela `Movimentos de Compras` (código `201` na pesquisa F1) já preenchida com cabeçalho, itens, tributos e financeiro do XML. O usuário ajusta o que for necessário (tipo de movimento, conta de financeiro, observações) e grava — gerando estoque e contas a pagar.
 - Após gravar, o XML passa para status `Importado` e ganha vínculo com o `ID_MOVIMENTO` criado.
 
 ### `Lançar Parcial`
@@ -265,7 +265,7 @@ Abrir o `Importar XML` diretamente (F1 → `204` → `Novo`) é um **caminho exc
 5. A tela `Importar XML NF-e` abre em inclusão, com todas as abas preenchidas a partir do XML armazenado.
 6. Aba `Itens`: **todos os itens devem aparecer vinculados** (descrição preenchida) porque o vínculo foi gravado em compras anteriores. Confira valores e quantidade.
 7. Aba `Financeiro`: confira as parcelas que vieram do XML.
-8. Clique em `Lançar NF-e`. A tela `Movimentos de Entrada` abre com tudo preenchido.
+8. Clique em `Lançar NF-e`. A tela `Movimentos de Compras` abre com tudo preenchido.
 9. Ajuste o `Tipo de Movimento` se necessário e grave.
 10. O XML passa para status `Importado` e o vínculo aparece nas colunas `M-` da Manifestação.
 

--- a/Fiscal/documentacao_importar_xml.md
+++ b/Fiscal/documentacao_importar_xml.md
@@ -75,26 +75,28 @@ Cada linha representa um XML carregado e traz, entre outras colunas: `Status`, `
 
 ## 📥 Importar um novo XML
 
-A importação começa quando o usuário entra no **modo de inclusão** (botão `Novo` da faixa padrão de operações).
+### O caminho recomendado: a partir da Manifestação do Destinatário
 
-A tela abre a sub-aba **`XML`** com dois grupos:
+A forma **padrão** de lançar a entrada de uma NF-e no Sol.NET é **não abrir a tela `Importar XML` diretamente**. O fluxo correto começa na [Manifestação do Destinatário](documentacao_manifestacao_destinatario.md) (tela `401`):
 
-- **Manifesto** — campo `Chave de Acesso` (44 dígitos). Pode ser preenchido manualmente ou vem preenchido automaticamente quando a tela é aberta pela Manifestação do Destinatário.
-- **Arquivo** — campo `Caminho` para selecionar o arquivo `.xml` no computador. O botão à direita do campo abre o seletor de arquivos; o botão à esquerda limpa o caminho.
+1. Pressione **F1** → `401` para abrir a `Manifestação do Destinatário`.
+2. Localize a NF-e no grid (filtros por loja, período, fornecedor, chave de acesso etc.).
+3. Com a linha selecionada, clique no botão **`NF-e`** (entre os botões `Zerar NSU` e `Confirmar`).
+4. O Sol.NET abre a tela `Importar XML NF-e` **já em modo de inclusão**, carrega o XML armazenado no banco (baixado pelo `Sol.NET_MonitorNFCe`) e preenche todas as abas automaticamente.
+5. Confira, vincule itens pendentes (se houver) e use `Lançar NF-e` para gerar o movimento.
 
-### Como o XML é localizado
+Esse caminho é o recomendado porque garante que o XML usado é o oficial da SEFAZ (vinculado à manifestação) e dispensa qualquer manipulação de arquivo `.xml` no disco.
 
-Há dois caminhos típicos:
+### Caminho alternativo: carregar um `.xml` de arquivo
 
-1. **Selecionar o `.xml` direto do disco**
-   - Clique no botão de busca à direita do campo `Caminho` e escolha o arquivo.
-   - Se o nome do arquivo for a própria chave de acesso (formato padrão), o campo `Chave de Acesso` é preenchido automaticamente.
-   - Confirme o lançamento (botão `Importar`) — o Sol.NET lê o XML e popula todas as abas.
+Há casos em que o XML não veio pela SEFAZ — fornecedor enviou por e-mail, pendrive, recebimento em outra loja, etc. Para esses casos:
 
-2. **Vir da Manifestação do Destinatário**
-   - O usuário, no grid de Manifestação, dispara a ação de lançar a entrada de uma NF-e baixada.
-   - A tela `Importar XML` abre já com a chave preenchida e busca o XML armazenado no banco.
-   - O processamento é igual ao caminho 1.
+1. Abra a tela `Importar XML NF-e` (F1 → `204`).
+2. Clique em `Novo` para entrar em modo de inclusão.
+3. Na sub-aba **`XML`**, grupo **`Arquivo`**, use o botão à direita do campo `Caminho` para escolher o `.xml` no computador (o botão à esquerda limpa o caminho).
+4. O Sol.NET lê o arquivo e preenche cabeçalho, fornecedor, itens, financeiro e tributos.
+
+> 💡 **O campo `Chave de Acesso` (grupo `Manifesto`) não é editável para iniciar uma importação.** Esse campo apenas **exibe** a chave de acesso de um XML já carregado (seja vindo da Manifestação, seja extraído do arquivo selecionado). Não digite a chave manualmente esperando que o sistema baixe o XML — não há essa ação.
 
 ### O que o Sol.NET faz ao ler o XML
 
@@ -239,37 +241,39 @@ Imprime o **Documento Auxiliar da NF-e** a partir do XML armazenado. Funciona ta
 
 ## 🔗 Relação com a Manifestação do Destinatário
 
-A tela `Importar XML` é a **porta natural de saída** para os XMLs que chegam pela [Manifestação do Destinatário](documentacao_manifestacao_destinatario.md):
+A tela [Manifestação do Destinatário](documentacao_manifestacao_destinatario.md) é a **porta de entrada padrão** dos XMLs no Sol.NET. O fluxo correto é sempre:
 
-- Os XMLs baixados pelo `Sol.NET_MonitorNFCe` ficam armazenados no banco.
-- Após a manifestação (Confirmação ou Ciência), o usuário pode lançar a entrada **direto pelo grid da Manifestação** — o Sol.NET abre a tela `Importar XML` com a chave de acesso já preenchida.
-- Quando o XML já está no `Importar XML`, o grid da Manifestação passa a mostrar as colunas `M-` (do movimento), permitindo conferir divergências (valor, data, número) entre o que o fornecedor emitiu e o que foi lançado.
+1. O `Sol.NET_MonitorNFCe` (aplicação à parte) baixa periodicamente os XMLs da SEFAZ e grava no banco.
+2. O usuário abre a `Manifestação do Destinatário` (tela `401`), localiza a nota e a manifesta (`Confirmação`, `Ciência` etc.).
+3. Com a linha selecionada, clica no botão **`NF-e`** (entre `Zerar NSU` e `Confirmar`). O Sol.NET abre a tela `Importar XML` já em inclusão, carrega o XML do banco e preenche todas as abas.
+4. Depois de gravado o movimento via `Lançar NF-e`, o grid da Manifestação passa a mostrar as colunas `M-` (do movimento), permitindo conferir divergências (valor, data, número) entre o que o fornecedor emitiu e o que foi lançado.
 
-Esse caminho é o **uso recomendado**: o XML chega oficialmente pela SEFAZ, é validado pela manifestação, e só então vira movimento via `Importar XML`. Carregar o XML de fontes externas (`.xml` recebido por e-mail, USB, etc.) também funciona, mas não substitui a manifestação.
+Abrir o `Importar XML` diretamente (F1 → `204` → `Novo`) é um **caminho excepcional**, usado apenas quando o XML chegou por fora da SEFAZ (e-mail, pendrive, outra loja). O fluxo principal sempre passa pela Manifestação.
 
 ---
 
 ## 💡 Exemplos Práticos
 
-### Exemplo 1 — Entrada normal de fornecedor recorrente
+### Exemplo 1 — Entrada normal de fornecedor recorrente (fluxo padrão via Manifestação)
 
-**Cenário**: o fornecedor enviou a mercadoria com NF-e. O cliente já comprou várias vezes desse fornecedor.
+**Cenário**: o fornecedor enviou a mercadoria com NF-e. O `Sol.NET_MonitorNFCe` já baixou o XML da SEFAZ. O cliente já comprou várias vezes desse fornecedor.
 
-1. Abra a tela `Importar XML NF-e` (F1 → `204`).
-2. Clique em `Novo` para entrar em modo de inclusão.
-3. Selecione o arquivo `.xml` no campo `Caminho` (botão à direita).
-4. O Sol.NET lê o XML; vá direto para a aba `Itens`.
-5. **Todos os itens devem aparecer vinculados** (descrição preenchida) porque o vínculo foi gravado em compras anteriores. Confira valores e quantidade.
-6. Aba `Financeiro`: confira as parcelas que vieram do XML.
-7. Clique em `Lançar NF-e`. A tela `Movimentos de Entrada` abre com tudo preenchido.
-8. Ajuste o `Tipo de Movimento` se necessário e grave.
-9. O XML passa para status `Importado` e some da pendência.
+1. Abra a `Manifestação do Destinatário` (F1 → `401`).
+2. Localize a NF-e no grid (filtros por loja, fornecedor, período ou chave de acesso).
+3. Se ainda não manifestou, clique em `Confirmar(1)` (ou `Ciência(4)` quando aplicável).
+4. Com a linha selecionada, clique no botão **`NF-e`** (entre `Zerar NSU` e `Confirmar`).
+5. A tela `Importar XML NF-e` abre em inclusão, com todas as abas preenchidas a partir do XML armazenado.
+6. Aba `Itens`: **todos os itens devem aparecer vinculados** (descrição preenchida) porque o vínculo foi gravado em compras anteriores. Confira valores e quantidade.
+7. Aba `Financeiro`: confira as parcelas que vieram do XML.
+8. Clique em `Lançar NF-e`. A tela `Movimentos de Entrada` abre com tudo preenchido.
+9. Ajuste o `Tipo de Movimento` se necessário e grave.
+10. O XML passa para status `Importado` e o vínculo aparece nas colunas `M-` da Manifestação.
 
 ### Exemplo 2 — Primeira compra de um fornecedor novo
 
-**Cenário**: fornecedor novo, ainda não cadastrado no Sol.NET, com itens nunca comprados.
+**Cenário**: fornecedor novo, ainda não cadastrado no Sol.NET, com itens nunca comprados. O XML já foi baixado pela Manifestação.
 
-1. Carregue o XML como no exemplo anterior.
+1. Manifeste a nota e abra pelo botão `NF-e` como no Exemplo 1.
 2. Mensagem `( razão social ) NÃO É SUA EMPRESA!` **não** aparece — o destinatário (você) está correto.
 3. A aba `Cabeçalho` mostra o fornecedor com `Fornecedor` em branco. Clique no botão **`Cadastrar fornecedor`** à direita do campo (ícone de adicionar) — o cadastro de pessoas abre com CNPJ, razão, endereço já preenchidos do XML. Salve.
 4. Volte para a aba `Itens`. Todos os itens estão sem descrição (sem vínculo).
@@ -277,21 +281,20 @@ Esse caminho é o **uso recomendado**: o XML chega oficialmente pela SEFAZ, é v
 6. Se o produto **não existe**, vá para inclusão dentro do `Cadastro de Produtos`. Os campos `Cód. Fornecedor`, `EAN Fornecedor` e `Descrição Fornecedor` já vêm preenchidos do XML — complete o restante (NCM, CST, unidade, preço de venda) e salve.
 7. Repita para os demais itens. A partir da segunda compra, esse fornecedor vai entrar como no Exemplo 1.
 
-### Exemplo 3 — XML carregado em duplicidade
+### Exemplo 3 — Tentativa de duplicidade
 
-**Cenário**: o usuário tenta carregar uma NF-e que já foi importada antes.
+**Cenário**: o usuário tenta lançar uma NF-e que já foi importada antes (por exemplo, abriu o `Importar XML` direto com `Novo` e selecionou um `.xml` cujo registro já existe).
 
-1. Selecione o arquivo `.xml`.
-2. O Sol.NET tenta processar e mostra `Chave de Acesso já Cadastrada!`.
-3. A tela limpa o campo e abre o registro existente na aba de busca para que o usuário confirme.
-4. Se o registro anterior já virou movimento (`Status = Importado`), nada precisa ser feito — a nota já está lançada.
-5. Se o registro anterior está em `Edição`, abra-o pelo grid e termine o lançamento por lá.
+1. Após o carregamento, o Sol.NET detecta a chave já cadastrada e mostra `Chave de Acesso já Cadastrada!`.
+2. A tela limpa o campo e abre o registro existente na aba de busca para que o usuário confirme.
+3. Se o registro anterior já virou movimento (`Status = Importado`), nada precisa ser feito — a nota já está lançada.
+4. Se o registro anterior está em `Edição`, abra-o pelo grid e termine o lançamento por lá.
 
 ### Exemplo 4 — Recebimento parcial
 
 **Cenário**: a NF-e tem 10 itens, mas só 7 chegaram fisicamente.
 
-1. Carregue o XML normalmente.
+1. Abra a nota pelo fluxo da Manifestação (Exemplo 1, passos 1–5).
 2. Vincule todos os 10 itens ao cadastro.
 3. Na aba `Itens`, marque (na coluna `Sel.`) apenas os 7 itens que chegaram.
 4. Ajuste a quantidade dos 7 itens se houver divergência de unidade.

--- a/Fiscal/documentacao_importar_xml.md
+++ b/Fiscal/documentacao_importar_xml.md
@@ -1,0 +1,316 @@
+# 📄 Importar XML NF-e - Sol.NET
+
+## 🎯 Visão Geral
+
+A tela **Importar XML NF-e** é o ponto onde o Sol.NET **lê o arquivo `.xml` de uma NF-e** (emitida por um fornecedor ou pela própria empresa) e o transforma em um movimento de entrada — ou registra a saída correspondente, no caso de NF-e própria.
+
+A tela faz três coisas principais:
+
+1. **Carregar o XML** e extrair automaticamente cabeçalho, fornecedor, itens, tributos e duplicatas.
+2. **Vincular cada item do XML a um produto do cadastro** — manualmente, com duplo clique, ou automaticamente pelo código do fornecedor.
+3. **Lançar a NF-e na Movimentação** como uma entrada concreta (com seus três modos: normal, parcial ou própria), gerando estoque, financeiro e demais reflexos.
+
+A tela também mantém o **histórico de todos os XMLs já carregados**, com filtros por loja, fornecedor, período, situação e conferência — funcionando como um diário de entradas a partir de NF-e.
+
+### Para que serve
+
+- ✅ Lançar a entrada de mercadoria de fornecedor a partir do XML, sem digitar nota manualmente
+- ✅ Vincular produtos do XML ao cadastro de produtos (com criação rápida de produtos novos)
+- ✅ Comparar o que o fornecedor enviou no XML com o que foi conferido fisicamente
+- ✅ Imprimir o **DANFE** a partir do XML
+- ✅ Lançar **parcialmente** uma NF-e quando apenas parte da mercadoria foi recebida
+- ✅ Registrar a saída de uma NF-e **emitida pela própria empresa** que precisa virar movimento
+
+### Quando o suporte é acionado
+
+- "Aparece *Chave de Acesso já Cadastrada*" → mesma NF-e foi carregada duas vezes; orientar como localizar o registro anterior.
+- "Aparece *( ... ) NÃO É SUA EMPRESA*" → o CNPJ do destinatário no XML não bate com nenhuma loja do Sol.NET; orientar conferência da loja ou da nota.
+- "Não consigo vincular o produto" → o item ainda não tem código do fornecedor cadastrado; explicar o duplo clique no item.
+- "Lancei a NF-e mas o financeiro não veio" → o lançamento de duplicatas é controlado por configuração; verificar se a NF-e tem parcelas no XML e se o financeiro foi gerado.
+
+---
+
+## 🚪 Como acessar
+
+A tela é aberta pela pesquisa universal:
+
+1. Pressione **F1** em qualquer ponto do Sol.NET.
+2. Digite **`204`** (código da tela) ou parte do nome **Importar XML**.
+3. Confirme para abrir a tela `Importar XML NF-e`.
+
+A tela também é aberta **automaticamente a partir da Manifestação do Destinatário** quando o usuário escolhe lançar a entrada de uma NF-e baixada da SEFAZ — nesse caminho, a chave de acesso já vem preenchida.
+
+---
+
+## 🔍 Consulta de XMLs já importados
+
+Ao abrir a tela, a primeira coisa que o usuário vê é o grid com os XMLs já carregados no Sol.NET. Os filtros ficam acima do grid, distribuídos em duas guias de pesquisa.
+
+### Filtros principais (1ª guia)
+
+| Filtro | O que faz |
+|--------|-----------|
+| `Descrição da Loja` | Limita o resultado a uma loja específica. Por padrão traz todas as lojas que o usuário tem acesso. |
+| `Status` | `Edição` (importado mas ainda não lançado), `Finalizado` (pronto para lançar), `Importado` (já gerou movimento). |
+| `Status Conferência` | `Não Conferido`, `Em Andamento`, `Finalizada Sem Divergência`, `Finalizada Com Divergência`. Veja o documento [Conferência de XML](documentacao_conferencia_xml.md). |
+| `Campo a pesquisar` | Define o campo: `Razão/Fantasia`, `Pessoas`, `Série`, `Nº Documento`, `Chave de Acesso`, `Total`, `UF`. |
+| `Condição` | Operador da busca: `Contém`, `Inicia Com`, `=`, `>`, `<`, `>=`, `<=`, `<>`, `Entre`, `Lista`, `Fora da Lista`. |
+| `Data` | Critério temporal: `Emissão` (do XML) ou `Cadastro` (quando entrou no Sol.NET). |
+| `Inicial` / `Final` | Intervalo de datas. |
+
+### Filtros adicionais (2ª guia)
+
+| Filtro | O que faz |
+|--------|-----------|
+| `Financeiro` | `Não Lançados` (XMLs sem duplicatas geradas) ou `Lançados`. |
+| `Operações` | `Internas` (entradas) ou `Externas` (saídas / emissão própria). |
+
+### O que o grid mostra
+
+Cada linha representa um XML carregado e traz, entre outras colunas: `Status`, `Descrição da Loja`, `Sigla Loja`, `Data Emissão`, `Série`, `Nº Doc.`, `Total Nota`, `Qt. Produtos`, `Conf.` (status de conferência), `Razão Social`, `Fantasia`, `Pessoa`, `Cidade`, `Chave de Acesso`, `Emissão` (Própria / Terceiro), `Comportamento` (Entrada / Saída), os valores fiscais (ICMS ST, IPI, Frete, Seguro, FCP, etc.), `Status Conferência`, `Financeiro` (`LANÇADO` / `NÃO LANÇADO`) e `Usuário Conferência`.
+
+> 💡 As cores do `Status Conferência` no grid mudam conforme o andamento — uma coluna que vira amarela ou vermelha indica divergência ou conferência em andamento. Veja [Conferência de XML](documentacao_conferencia_xml.md).
+
+---
+
+## 📥 Importar um novo XML
+
+A importação começa quando o usuário entra no **modo de inclusão** (botão `Novo` da faixa padrão de operações).
+
+A tela abre a sub-aba **`XML`** com dois grupos:
+
+- **Manifesto** — campo `Chave de Acesso` (44 dígitos). Pode ser preenchido manualmente ou vem preenchido automaticamente quando a tela é aberta pela Manifestação do Destinatário.
+- **Arquivo** — campo `Caminho` para selecionar o arquivo `.xml` no computador. O botão à direita do campo abre o seletor de arquivos; o botão à esquerda limpa o caminho.
+
+### Como o XML é localizado
+
+Há dois caminhos típicos:
+
+1. **Selecionar o `.xml` direto do disco**
+   - Clique no botão de busca à direita do campo `Caminho` e escolha o arquivo.
+   - Se o nome do arquivo for a própria chave de acesso (formato padrão), o campo `Chave de Acesso` é preenchido automaticamente.
+   - Confirme o lançamento (botão `Importar`) — o Sol.NET lê o XML e popula todas as abas.
+
+2. **Vir da Manifestação do Destinatário**
+   - O usuário, no grid de Manifestação, dispara a ação de lançar a entrada de uma NF-e baixada.
+   - A tela `Importar XML` abre já com a chave preenchida e busca o XML armazenado no banco.
+   - O processamento é igual ao caminho 1.
+
+### O que o Sol.NET faz ao ler o XML
+
+Em uma única passada, o sistema extrai e preenche:
+
+- **Cabeçalho** — natureza da operação, tipo de pagamento, série, número, data de emissão, protocolo, chave de acesso, informações adicionais.
+- **Empresa destinatária** — busca pelo CNPJ do destinatário no XML. Se bate com alguma loja, preenche `Descrição da Loja` e `Sigla`. Se **não bate**, mostra `( ... ) NÃO É SUA EMPRESA!` e o lançamento fica bloqueado (a menos que a empresa tenha autorizado importar terceiros).
+- **Fornecedor / Emitente** — razão social, fantasia, CNPJ/CPF, IE, telefone, endereço completo, UF, CEP. Se já existe no cadastro de pessoas, vincula automaticamente; se não existe, o usuário pode cadastrá-lo pelo campo `Fornecedor`.
+- **Comportamento** — `Entrada` ou `Saída`, lido do XML (`Ide.tpNF`).
+- **Emissão** — `PROPRIA` quando o CNPJ do emitente também é uma loja cadastrada; `TERCEIRO` caso contrário.
+- **Itens** — todos os produtos do XML, com código do fornecedor, EAN, descrição, unidade, quantidade, valor unitário, descontos, totais, e os tributos (ICMS, ICMS ST, IPI, FCP, COFINS, PIS).
+- **Financeiro** — duplicatas / parcelas (número, vencimento, valor) lidas das tags de cobrança.
+- **Totais** — descontos, acréscimos, frete, seguro, bases de cálculo, ICMS desonerado, FCP.
+
+### Erros de carregamento comuns
+
+| Mensagem | O que significa | Como resolver |
+|----------|-----------------|---------------|
+| `Arquivo XML Inválido!` | O arquivo selecionado não é um XML de NF-e válido (corrompido, esquema errado, arquivo trocado). | Selecionar o arquivo correto; pedir ao fornecedor um novo XML se necessário. |
+| `Chave de Acesso já Cadastrada!` | Já existe um registro no Sol.NET com essa chave. | Use os filtros para localizar o registro existente em vez de carregar novamente. |
+| `( fornecedor ) NÃO É SUA EMPRESA!` | O CNPJ do destinatário no XML não bate com nenhuma loja. | Verificar se a NF-e foi emitida para o CNPJ correto. Se a empresa permite importar para terceiros, habilitar o campo `Descrição da Loja` para escolher manualmente. |
+| `Pessoa não cadastrada!` ao vincular item | O fornecedor do XML ainda não está no cadastro de pessoas. | Cadastrar o fornecedor primeiro (botão à direita do campo `Fornecedor`). |
+
+---
+
+## 🧭 Sub-abas do formulário
+
+Depois de carregado, o XML pode ser conferido e editado nas seguintes abas:
+
+### Aba `XML`
+Mostra a estrutura crua do arquivo (memo `XML`) e os grupos `Manifesto` / `Arquivo`. Útil para verificar o conteúdo bruto quando algo no parser parece divergir do que está na nota.
+
+### Aba `Cabeçalho`
+Reúne os campos do cabeçalho da NF-e, agrupados em três blocos:
+
+- **Identificação** — `Descrição da Loja`, `Sigla`, `Status`, `Natureza da Operação`, `Tipo Pagamento`, `CNPJ`, `Nº Documento`, `Data Emissão`, `Série`, `Emissão` (Própria / Terceiro), `Comportamento` (Entrada / Saída).
+- **Dados do Fornecedor** — `Razão Social`, `Fantasia`, `IE`, `CNPJ/CPF`, `Telefone`, `Endereço`, `Nº`, `Bairro`, `Cidade`, `Cód. Cidade`, `UF`, `CEP`, `Complementos`, `Fornecedor` (vínculo com cadastro de pessoas), `Informações Adicionais`.
+- **Autorização** — `Protocolo` e `Chave de Acesso` (somente leitura, extraídos do XML).
+
+### Aba `Itens`
+A aba mais usada. Aqui o usuário **confere e vincula** cada produto do XML ao cadastro de produtos. Veja a próxima seção.
+
+Dentro de `Itens` há ainda duas sub-abas:
+
+- **`Totais`** — totalizadores fiscais e financeiros (Desc. Produtos, Acrésc. Produtos, Frete, Seguro, Base ICMS, Valor ICMS, Base ICMS ST, Valor ICMS ST, Base IPI, Valor IPI, Cred ICMS SN).
+- **`Tributação`** — bases e valores de PIS, COFINS, FCP (Valor Total FCP, Vl. FCP Ret. ST, Vl. FCP Ret Ant. ST) e ICMS Desonerado.
+
+### Aba `Financeiro`
+Lista as **parcelas / duplicatas** trazidas do XML, com `Número`, `Vencimento` e `Valor`. Esse grid alimenta a geração de contas a pagar no momento do lançamento da NF-e.
+
+### Aba `Conferência`
+**Visível apenas quando a empresa tem o tipo de conferência XML habilitado** no `Cadastro de Empresas`. É onde o conferente físico marca o que foi efetivamente recebido. Veja o documento dedicado: [Conferência de XML](documentacao_conferencia_xml.md).
+
+---
+
+## 🛒 Vinculando itens do XML ao cadastro de produtos
+
+Esta é a parte que mais consome tempo no dia a dia e onde o suporte mais é acionado. Cada linha da aba `Itens` representa um produto no XML do fornecedor — e cada uma precisa "casar" com um produto do cadastro **antes** da NF-e poder ser lançada como movimento.
+
+### Como o Sol.NET tenta vincular automaticamente
+
+Ao **selecionar o fornecedor** (ou quando o XML é carregado e o fornecedor já existe no cadastro), o sistema:
+
+1. Pega o **código do fornecedor** (`Cód. Forn.`) de cada item do XML.
+2. Procura no cadastro de produtos um produto que **já tenha esse código associado a esse fornecedor**.
+3. Se encontrar, preenche automaticamente: `Código`, `Código Barra`, `Descrição` (do produto no cadastro), `Custo Inicial`, e calcula a conversão de unidade quando aplicável (`Unid.` × `Unid(P)`).
+
+Itens vinculados aparecem com a descrição do produto cadastrado preenchida; itens não vinculados ficam com `Descrição` vazia.
+
+### Quando o vínculo precisa ser manual
+
+Sempre que uma das condições abaixo é verdadeira, o vínculo automático falha e o usuário tem que decidir:
+
+- O **fornecedor é novo** ou ainda não tem produtos com código cadastrado.
+- O **código do fornecedor** está em branco no XML.
+- O produto **nunca foi comprado** desse fornecedor antes.
+
+Nesses casos, a coluna `Descrição` do item aparece em branco. O usuário precisa **abrir o item e fazer a vinculação manual**:
+
+1. **Duplo clique** sobre a linha do item (ou pressione Enter sobre ela).
+2. A tela `Cadastro de Produtos` (código `40` na pesquisa F1) abre **em modo pesquisa**, já filtrada para mostrar produtos. A descrição que aparece no topo é o nome do produto **no fornecedor** (o que veio no XML), para ajudar a identificar.
+3. Localize o produto correspondente no cadastro e confirme.
+4. O Sol.NET grava o vínculo: a partir daí, **qualquer próxima compra desse mesmo produto com esse fornecedor é vinculada automaticamente** (pelo mesmo `Cód. Forn.`).
+
+### Cadastrando um produto novo durante o vínculo
+
+Se o produto **não existe** no cadastro, o usuário pode incluí-lo **a partir da mesma janela** que abriu para vincular:
+
+1. No `Cadastro de Produtos` que abriu, vá para o modo de inclusão.
+2. Os campos `Código do Fornecedor`, `EAN do Fornecedor` e `Descrição no Fornecedor` já vêm pré-preenchidos com os valores do XML — isso ajuda a manter consistência.
+3. Preencha os demais campos do produto (descrição interna, unidade, NCM, CST, etc.) e salve.
+4. Ao retornar à tela `Importar XML`, o item fica vinculado ao produto recém-criado.
+
+### Regras e bloqueios no vínculo
+
+| Situação | O que o Sol.NET faz |
+|----------|---------------------|
+| Produto selecionado é do tipo **Serviço** | Bloqueia com `Não Permitido, Tipo Serviço!`. Itens de NF-e de mercadoria não podem casar com produtos de serviço. |
+| Produto está marcado para **desagregação** | Bloqueia com `Não Permitido, Produto configurado para desagregação!`. Esses produtos têm fluxo próprio. |
+| Produto é **linkado** e a configuração proíbe | Bloqueia com `Não Permitido, Vinculo de produto linkado!`. A regra é controlada por configuração geral do sistema. |
+| Produto é **linkado** e a configuração permite | Mostra um aviso `Produto Linkado Selecionado!` com código, código de barra e descrição — o usuário precisa confirmar leitura. |
+| Item está com **quantidade zero** ou **valor zero** | Não bloqueia o vínculo, mas é sinalizado ao tentar lançar a NF-e. |
+| **Diferença de custo** acima do percentual configurado (margem positiva ou negativa) | Avisa no momento do lançamento — o usuário pode prosseguir ou rever. |
+
+### Coluna `Conf.` no grid de itens
+
+Quando o item é vinculado, a coluna `Conf.` (de "conferido") mostra que o item está pronto para virar movimento. Itens sem vínculo permanecem destacados — o **lançamento da NF-e é bloqueado** enquanto houver itens não vinculados, com a mensagem `Não Existe Nenhum Item com Vinculo!`.
+
+---
+
+## ▶️ Lançar a NF-e na movimentação
+
+Depois que **todos os itens estão vinculados** e o cabeçalho está correto, o usuário decide qual tipo de lançamento fazer. A faixa de botões no rodapé da tela traz três variações de "Lançar" e a impressão do DANFE.
+
+### `Lançar NF-e` — o fluxo padrão
+
+Para a maioria absoluta dos casos, este é o botão a usar.
+
+- **Quando usar**: NF-e de **entrada** vinda de fornecedor (mercadoria recebida da forma como a nota descreve, parcelas a pagar como vieram no XML).
+- **O que acontece**: o Sol.NET abre a tela `Movimentos de Entrada` (código `203` na pesquisa F1) já preenchida com cabeçalho, itens, tributos e financeiro do XML. O usuário ajusta o que for necessário (tipo de movimento, conta de financeiro, observações) e grava — gerando estoque e contas a pagar.
+- Após gravar, o XML passa para status `Importado` e ganha vínculo com o `ID_MOVIMENTO` criado.
+
+### `Lançar Parcial`
+
+- **Quando usar**: quando a mercadoria foi recebida só **em parte** e a empresa quer registrar a entrada **apenas dos itens efetivamente recebidos** — devoluções parciais na origem, falta de mercadoria, conferência divergente para mais ou para menos.
+- **O que acontece**: o fluxo é idêntico ao `Lançar NF-e`, mas o usuário pode marcar/desmarcar itens e ajustar quantidades antes da gravação do movimento. O XML continua na tela e pode ser lançado novamente para o restante (ou referenciado em uma divergência fiscal).
+
+### `Lançar Próprio`
+
+- **Quando usar**: para NF-e em que **a empresa é a própria emitente** (campo `Emissão` = `PROPRIA`). Acontece, por exemplo, quando o XML de uma nota de saída/devolução emitida pela empresa volta da SEFAZ e precisa ser conciliado.
+- **Bloqueio**: o botão verifica `Emissão`. Se a NF-e não for emissão própria, mostra `Não Permitido! Somente Emissão PROPRIA.` e cancela.
+- **Verificações de integridade**:
+  - Se já existe um movimento vinculado mas ele foi **cancelado**, o aviso `Movimentação Cancelada! Lançar NF-e Novamente.` aparece e o vínculo é desfeito automaticamente.
+  - Se o movimento vinculado foi **excluído**, o aviso `Movimentação Excluida! Lançar NF-e Novamente.` aparece e o vínculo também é desfeito.
+- **O que acontece**: o Sol.NET abre a tela `Movimentação` (saída) preenchida com os dados do XML. Após gravar, o XML fica como `Importado` e vinculado ao movimento de saída.
+
+### `DANFE`
+
+Imprime o **Documento Auxiliar da NF-e** a partir do XML armazenado. Funciona tanto a partir do grid (após selecionar uma linha) quanto da tela de cadastro (já com o XML carregado). O sistema abre o preview com opção de configurar a impressora.
+
+---
+
+## 🔗 Relação com a Manifestação do Destinatário
+
+A tela `Importar XML` é a **porta natural de saída** para os XMLs que chegam pela [Manifestação do Destinatário](documentacao_manifestacao_destinatario.md):
+
+- Os XMLs baixados pelo `Sol.NET_MonitorNFCe` ficam armazenados no banco.
+- Após a manifestação (Confirmação ou Ciência), o usuário pode lançar a entrada **direto pelo grid da Manifestação** — o Sol.NET abre a tela `Importar XML` com a chave de acesso já preenchida.
+- Quando o XML já está no `Importar XML`, o grid da Manifestação passa a mostrar as colunas `M-` (do movimento), permitindo conferir divergências (valor, data, número) entre o que o fornecedor emitiu e o que foi lançado.
+
+Esse caminho é o **uso recomendado**: o XML chega oficialmente pela SEFAZ, é validado pela manifestação, e só então vira movimento via `Importar XML`. Carregar o XML de fontes externas (`.xml` recebido por e-mail, USB, etc.) também funciona, mas não substitui a manifestação.
+
+---
+
+## 💡 Exemplos Práticos
+
+### Exemplo 1 — Entrada normal de fornecedor recorrente
+
+**Cenário**: o fornecedor enviou a mercadoria com NF-e. O cliente já comprou várias vezes desse fornecedor.
+
+1. Abra a tela `Importar XML NF-e` (F1 → `204`).
+2. Clique em `Novo` para entrar em modo de inclusão.
+3. Selecione o arquivo `.xml` no campo `Caminho` (botão à direita).
+4. O Sol.NET lê o XML; vá direto para a aba `Itens`.
+5. **Todos os itens devem aparecer vinculados** (descrição preenchida) porque o vínculo foi gravado em compras anteriores. Confira valores e quantidade.
+6. Aba `Financeiro`: confira as parcelas que vieram do XML.
+7. Clique em `Lançar NF-e`. A tela `Movimentos de Entrada` abre com tudo preenchido.
+8. Ajuste o `Tipo de Movimento` se necessário e grave.
+9. O XML passa para status `Importado` e some da pendência.
+
+### Exemplo 2 — Primeira compra de um fornecedor novo
+
+**Cenário**: fornecedor novo, ainda não cadastrado no Sol.NET, com itens nunca comprados.
+
+1. Carregue o XML como no exemplo anterior.
+2. Mensagem `( razão social ) NÃO É SUA EMPRESA!` **não** aparece — o destinatário (você) está correto.
+3. A aba `Cabeçalho` mostra o fornecedor com `Fornecedor` em branco. Clique no botão **`Cadastrar fornecedor`** à direita do campo (ícone de adicionar) — o cadastro de pessoas abre com CNPJ, razão, endereço já preenchidos do XML. Salve.
+4. Volte para a aba `Itens`. Todos os itens estão sem descrição (sem vínculo).
+5. Duplo clique no primeiro item — abre o `Cadastro de Produtos` em pesquisa. Se o produto já existe no seu cadastro com outro código, localize-o e confirme — o sistema grava o vínculo para esse fornecedor.
+6. Se o produto **não existe**, vá para inclusão dentro do `Cadastro de Produtos`. Os campos `Cód. Fornecedor`, `EAN Fornecedor` e `Descrição Fornecedor` já vêm preenchidos do XML — complete o restante (NCM, CST, unidade, preço de venda) e salve.
+7. Repita para os demais itens. A partir da segunda compra, esse fornecedor vai entrar como no Exemplo 1.
+
+### Exemplo 3 — XML carregado em duplicidade
+
+**Cenário**: o usuário tenta carregar uma NF-e que já foi importada antes.
+
+1. Selecione o arquivo `.xml`.
+2. O Sol.NET tenta processar e mostra `Chave de Acesso já Cadastrada!`.
+3. A tela limpa o campo e abre o registro existente na aba de busca para que o usuário confirme.
+4. Se o registro anterior já virou movimento (`Status = Importado`), nada precisa ser feito — a nota já está lançada.
+5. Se o registro anterior está em `Edição`, abra-o pelo grid e termine o lançamento por lá.
+
+### Exemplo 4 — Recebimento parcial
+
+**Cenário**: a NF-e tem 10 itens, mas só 7 chegaram fisicamente.
+
+1. Carregue o XML normalmente.
+2. Vincule todos os 10 itens ao cadastro.
+3. Na aba `Itens`, marque (na coluna `Sel.`) apenas os 7 itens que chegaram.
+4. Ajuste a quantidade dos 7 itens se houver divergência de unidade.
+5. Clique em `Lançar Parcial`. A tela de movimento abre só com os itens marcados.
+6. Grave. O Sol.NET registra o movimento parcial e mantém o XML para complementação futura (ou para uma operação de divergência).
+
+---
+
+## ❓ FAQ / Problemas Comuns
+
+A lista completa está em [FAQ — Importar XML](faq_importar_xml.md). Os mais frequentes:
+
+- **"O XML do fornecedor não está sendo aceito"** → quase sempre arquivo corrompido ou XML de NFC-e (consumidor) em vez de NF-e. Peça novo arquivo.
+- **"Aparece *NÃO É SUA EMPRESA*"** → CNPJ do destinatário no XML difere do CNPJ das lojas cadastradas. Conferir loja correta ou autorização para importar terceiro.
+- **"Não estou conseguindo vincular um item específico"** → o produto pode estar como **Serviço** ou marcado para **desagregação**; nesses casos o vínculo é bloqueado por regra.
+- **"Importei mas o financeiro não veio"** → o XML pode não ter trazido a tag de cobrança (NF-e à vista, por exemplo), ou as parcelas foram canceladas na conferência. Verifique a aba `Financeiro`.
+
+---
+
+**Última atualização**: Maio de 2026  
+**Versão**: 1.0  
+**Público-alvo**: Equipe de suporte Sol.NET, usuários operacionais e administradores

--- a/Fiscal/documentacao_manifestacao_destinatario.md
+++ b/Fiscal/documentacao_manifestacao_destinatario.md
@@ -178,7 +178,7 @@ Clicando com o botão direito no grid, aparecem ações rápidas:
 
 ## 🔗 Vínculo com movimentos do Sol.NET
 
-Quando uma NF-e baixada já foi importada como **entrada** na movimentação (via `Importar XML` ou lançada manualmente), o Sol.NET cria o vínculo automaticamente. Esse vínculo aparece de duas formas:
+Quando uma NF-e baixada já foi importada como **entrada** na movimentação (via [Importar XML](documentacao_importar_xml.md) ou lançada manualmente), o Sol.NET cria o vínculo automaticamente. Esse vínculo aparece de duas formas:
 
 1. **Colunas `M-` no grid** — replicam os dados do movimento ao lado dos dados da nota, permitindo conferir divergências (valor, data de emissão, número) entre o que o fornecedor emitiu e o que foi lançado.
 2. **Atalho `Ir para Movimentação`** (botão direito) — abre a entrada correspondente para consulta ou ajuste.

--- a/Fiscal/faq_importar_xml.md
+++ b/Fiscal/faq_importar_xml.md
@@ -2,7 +2,7 @@
 
 ## 🎯 Visão Geral
 
-Perguntas frequentes sobre a tela `Importar XML NF-e` (código `204` na pesquisa F1). Para o detalhamento dos fluxos, ver [Documentação Importar XML](documentacao_importar_xml.md) e o [Guia Rápido](guia_rapido_importar_xml.md).
+Perguntas frequentes sobre a tela `Importar XML NF-e` (código `204` na pesquisa F1). Para o detalhamento dos fluxos, consulte a [Documentação Importar XML](documentacao_importar_xml.md) e o [Guia Rápido](guia_rapido_importar_xml.md).
 
 ---
 
@@ -206,4 +206,4 @@ Detalhes em [Conferência de XML](documentacao_conferencia_xml.md).
 
 **Última atualização**: Maio de 2026  
 **Versão**: 1.0  
-**Público-alvo**: Equipe de suporte Sol.NET
+**Público-alvo**: Usuários e administradores do Sol.NET ERP

--- a/Fiscal/faq_importar_xml.md
+++ b/Fiscal/faq_importar_xml.md
@@ -1,0 +1,196 @@
+# 📄 FAQ — Importar XML NF-e - Sol.NET
+
+## 🎯 Visão Geral
+
+Perguntas frequentes sobre a tela `Importar XML NF-e` (código `204` na pesquisa F1). Para o detalhamento dos fluxos, ver [Documentação Importar XML](documentacao_importar_xml.md) e o [Guia Rápido](guia_rapido_importar_xml.md).
+
+---
+
+## 📥 Carregamento do XML
+
+### ❓ Onde fica o arquivo `.xml` que devo carregar?
+
+Depende da origem:
+
+- **Veio por e-mail/anexo**: salve o `.xml` em uma pasta de fácil acesso (ex.: `Documentos/XMLs/`) e selecione no campo `Caminho`.
+- **Veio da SEFAZ pela Manifestação**: o arquivo já está armazenado no banco do Sol.NET. Use o caminho via [Manifestação do Destinatário](documentacao_manifestacao_destinatario.md) (tela `401`) — a tela `Importar XML` abre com a chave preenchida e busca o XML sozinha.
+- **Veio em pendrive**: copie para o disco local antes de carregar; o seletor aceita qualquer caminho válido.
+
+### ❓ Posso carregar XML de NFC-e (cupom fiscal eletrônico)?
+
+Não. A tela é exclusiva para **NF-e** (modelo 55). Cupons fiscais têm fluxo próprio. Tentar carregar uma NFC-e resulta em `Arquivo XML Inválido!`.
+
+### ❓ Por que aparece "Arquivo XML Inválido!"?
+
+Causas mais comuns:
+
+- Arquivo corrompido (corte de transferência, e-mail truncado).
+- Arquivo é de outro modelo de documento (NFC-e, CT-e, NFS-e, MDF-e).
+- O `.xml` foi salvo como texto (extensão errada).
+- XML alterado manualmente em editor de texto e perdeu a assinatura.
+
+Solução: peça um novo XML diretamente ao fornecedor (ou redownload pela Manifestação).
+
+### ❓ Aparece "Chave de Acesso já Cadastrada!" mas eu não importei essa nota. Por quê?
+
+Possíveis razões:
+
+- Outro usuário já importou a NF-e antes.
+- O XML chegou pela Manifestação do Destinatário e foi pré-cadastrado.
+- A nota foi vinculada como entrada manual e o sistema mesmo importou o XML em segundo plano.
+
+Use o filtro `Campo a pesquisar` = `Chave de Acesso` para encontrar o registro existente e dar continuidade lá.
+
+---
+
+## 🏢 Empresa e fornecedor
+
+### ❓ "( razão social ) NÃO É SUA EMPRESA!" — o que isso significa?
+
+O CNPJ do **destinatário** do XML (a empresa que recebeu a nota) não bate com nenhuma loja cadastrada no Sol.NET. Verifique:
+
+1. Se a NF-e foi de fato emitida para a sua empresa (conferir CNPJ no DANFE).
+2. Se a loja correta está cadastrada no `Cadastro de Empresas`.
+3. Se há autorização para "importar terceiro" — algumas operações (transportadora, depósito) podem precisar dessa configuração; nesse caso o campo `Descrição da Loja` fica habilitado para seleção manual.
+
+### ❓ O fornecedor não existe no meu cadastro. Como cadastrar pelo `Importar XML`?
+
+Na aba `Cabeçalho`, clique no botão **`Cadastrar fornecedor`** (à direita do campo `Fornecedor`). O `Cadastro de Pessoas` abre em modo de inclusão com **CNPJ, razão social, endereço e demais campos do XML já preenchidos**. Complete o que faltar (tipo de pessoa, contato), salve, e o vínculo é gravado no XML automaticamente.
+
+### ❓ Existem dois fornecedores no cadastro com o mesmo CNPJ. Qual o sistema escolhe?
+
+Quando o sistema detecta múltiplos fornecedores com o mesmo CNPJ/CPF, abre uma janela auxiliar listando os possíveis e pede que o usuário **escolha qual deve ser vinculado**. Não há escolha automática — é decisão manual do operador.
+
+---
+
+## 🛒 Vínculo de itens
+
+### ❓ Por que alguns itens vêm vinculados automaticamente e outros não?
+
+O Sol.NET tenta casar pelo **código do fornecedor** (`Cód. Forn.` que veio no XML) com o que está cadastrado no produto. Se o produto **já foi comprado antes** desse mesmo fornecedor, o vínculo existe e o sistema reconhece. Para fornecedores ou produtos novos, o vínculo precisa ser feito manualmente uma vez — depois disso, fica automático.
+
+### ❓ Posso vincular um item de XML a vários produtos do cadastro (ou vice-versa)?
+
+Não. O vínculo é **um para um** por combinação (fornecedor + código do fornecedor → produto cadastrado). Se o fornecedor passa a entregar o mesmo código com características diferentes, o produto precisa ser desmembrado no cadastro.
+
+### ❓ "Não Permitido, Tipo Serviço!" ao vincular item — o que fazer?
+
+A nota é de mercadoria mas o usuário selecionou um produto cadastrado como **Serviço**. Soluções:
+
+- Confirme que o item realmente é mercadoria (não serviço); se for, encontre o produto correto.
+- Se realmente é um serviço, a NF-e não devia estar nessa tela — serviços têm fluxo próprio (NFS-e).
+
+### ❓ "Não Permitido, Produto configurado para desagregação!" — por que aparece?
+
+Produtos marcados para **desagregação** (kits, fardos que viram unidades) têm fluxo próprio na entrada. Não podem ser vinculados diretamente a um item de XML — o sistema bloqueia para evitar inconsistência de estoque. Se o item realmente é o produto desagregável, a entrada precisa seguir o fluxo específico.
+
+### ❓ Como saber se um item está vinculado?
+
+Olhando a coluna `Descrição` na aba `Itens`:
+
+- **Preenchida com a descrição do cadastro** → item vinculado.
+- **Em branco ou só com a descrição do fornecedor** → ainda precisa vincular.
+
+### ❓ Vinculei errado um item. Como corrigir?
+
+Enquanto o XML estiver com `Status = Edição` (ou seja, ainda não virou movimento), basta dar **duplo clique no item** novamente. O sistema reabre a pesquisa de produtos e o vínculo pode ser refeito. Depois do lançamento, ajustes precisam ser feitos diretamente na movimentação.
+
+### ❓ Cadastrei um produto novo a partir do `Importar XML`. Os dados do XML ficam salvos?
+
+Sim. Ao cadastrar o produto, o Sol.NET grava automaticamente:
+
+- O **código do fornecedor** (`Cód. Forn.`) na tabela de códigos de fornecedor.
+- O **EAN do fornecedor** (quando vier).
+- A **descrição do fornecedor** (a forma como o produto aparece na nota do fornecedor).
+
+Isso garante que **na próxima compra do mesmo produto desse mesmo fornecedor**, o vínculo será automático.
+
+---
+
+## ▶️ Lançamento do movimento
+
+### ❓ Qual a diferença entre os três botões "Lançar"?
+
+| Botão | Quando usar |
+|-------|-------------|
+| **`Lançar NF-e`** | Caso padrão — entrada de mercadoria conforme a nota. |
+| **`Lançar Parcial`** | Apenas parte da mercadoria chegou — marca-se na coluna `Sel.` os itens recebidos. |
+| **`Lançar Próprio`** | NF-e em que a empresa é a **emitente** (Emissão = `PROPRIA`). Bloqueado para terceiros. |
+
+### ❓ Posso lançar a NF-e sem vincular todos os itens?
+
+Não. O Sol.NET bloqueia com `Não Existe Nenhum Item com Vinculo!` se houver pelo menos um item sem produto cadastrado. Vincule todos antes de tentar lançar.
+
+### ❓ Lancei a NF-e mas o financeiro não foi gerado. Onde vejo?
+
+A aba `Financeiro` da tela `204` mostra as parcelas que vieram **no XML**. Se essa aba está vazia, o XML não trouxe a tag de cobrança (NF-e à vista, sem parcelamento, ou fornecedor não preencheu). Nesse caso, o financeiro precisa ser lançado manualmente em `Contas a Pagar`.
+
+### ❓ Aparece "Diferença de Custo de X%" no lançamento. Devo cancelar?
+
+É um **aviso**, não um bloqueio. O Sol.NET compara o custo do item no XML com o custo atual cadastrado e, quando passa de um percentual configurado, alerta. Decida com base no contexto:
+
+- **Aumento legítimo** (fornecedor reajustou preço) → confirmar e atualizar custo.
+- **Possível erro** (digitação errada do fornecedor, casa decimal trocada) → cancelar e revisar com o fornecedor.
+
+### ❓ Tentei `Lançar Próprio` e apareceu "Somente Emissão PROPRIA". O que fazer?
+
+A NF-e que está aberta é de **terceiro** (algum fornecedor é o emitente). O botão `Lançar Próprio` só funciona para notas emitidas pela própria empresa (típico de retorno de XML de uma saída). Use `Lançar NF-e` (ou `Lançar Parcial`).
+
+### ❓ Lancei o XML, mas vi que o movimento foi excluído depois. O vínculo ainda existe?
+
+Não. Quando o Sol.NET detecta que o movimento vinculado foi **excluído** ou **cancelado**, mostra a mensagem `Movimentação Excluida/Cancelada! Lançar NF-e Novamente.` e **desfaz o vínculo automaticamente**, voltando o XML para o status anterior. Basta clicar em `Lançar NF-e` de novo.
+
+---
+
+## 📨 Manifestação e DANFE
+
+### ❓ Preciso fazer a Manifestação antes de importar o XML?
+
+Legalmente, **sim**, para NF-e de terceiros emitidas contra o seu CNPJ. A `Confirmação da Operação` ou `Ciência da Emissão` precede o lançamento como entrada. Operacionalmente, o Sol.NET permite carregar um `.xml` diretamente — mas o caminho recomendado é via Manifestação, porque garante que o XML é o oficial da SEFAZ.
+
+Veja [Manifestação do Destinatário](documentacao_manifestacao_destinatario.md).
+
+### ❓ Posso imprimir o DANFE direto pela tela?
+
+Sim. O botão `DANFE` na faixa de botões imprime o documento auxiliar a partir do XML. Funciona tanto:
+
+- **Pelo grid** — selecione a linha da NF-e e clique em `DANFE`.
+- **No cadastro** — com o registro aberto, clique em `DANFE`.
+
+Se o XML não estiver no banco (caso raro de carga manual sem persistência), o sistema tenta imprimir a partir do arquivo `.xml` do caminho original.
+
+---
+
+## 🔍 Conferência de XML
+
+### ❓ Onde vejo se a conferência está ativa para minha empresa?
+
+No `Cadastro de Empresas` (código `100`), há a configuração `Tipo Conferência XML`. Quando habilitada, a aba `Conferência` aparece dentro do `Importar XML`. Veja o documento dedicado: [Conferência de XML](documentacao_conferencia_xml.md).
+
+> ⚠️ **Acesso de suporte necessário:** alterações no `Cadastro de Empresas` requerem permissão de acesso de suporte. Entre em contato com o suporte Hetosoft antes de realizar qualquer modificação nesta tela.
+
+### ❓ A coluna `Status Conferência` está vermelha. O que fazer?
+
+`Status Conferência` = `FINALIZADA COM DIVERGÊNCIA` indica que o conferente registrou diferença entre o que chegou e o que está no XML. Antes de lançar a NF-e:
+
+1. Abra o registro pelo grid.
+2. Vá para a aba `Conferência`.
+3. Veja os itens marcados com `TP_DIVERGENCIA = 1` — quantidade ou código diferente.
+4. Decida: lançar tudo conforme o XML, lançar parcial conforme conferência, ou tratar a divergência com o fornecedor.
+
+Detalhes em [Conferência de XML](documentacao_conferencia_xml.md).
+
+---
+
+## 🔗 Documentos relacionados
+
+- [Documentação Importar XML](documentacao_importar_xml.md) — referência completa
+- [Guia Rápido — Importar XML](guia_rapido_importar_xml.md) — checklist operacional
+- [Conferência de XML](documentacao_conferencia_xml.md) — fluxo da conferência física
+- [Manifestação do Destinatário](documentacao_manifestacao_destinatario.md) — porta de entrada dos XMLs da SEFAZ
+
+---
+
+**Última atualização**: Maio de 2026  
+**Versão**: 1.0  
+**Público-alvo**: Equipe de suporte Sol.NET

--- a/Fiscal/faq_importar_xml.md
+++ b/Fiscal/faq_importar_xml.md
@@ -178,7 +178,7 @@ Se o XML não estiver no banco (caso raro de carga manual sem persistência), o 
 
 ### ❓ Onde vejo se a conferência está ativa para minha empresa?
 
-No `Cadastro de Empresas` (código `100`), há a configuração `Tipo Conferência XML`. Quando habilitada, a aba `Conferência` aparece dentro do `Importar XML`. Veja o documento dedicado: [Conferência de XML](documentacao_conferencia_xml.md).
+No `Cadastro de Empresas` (código `1`), há a configuração `Tipo Conferência XML`. Quando habilitada, a aba `Conferência` aparece dentro do `Importar XML`. Veja o documento dedicado: [Conferência de XML](documentacao_conferencia_xml.md).
 
 > ⚠️ **Acesso de suporte necessário:** alterações no `Cadastro de Empresas` requerem permissão de acesso de suporte. Entre em contato com o suporte Hetosoft antes de realizar qualquer modificação nesta tela.
 

--- a/Fiscal/faq_importar_xml.md
+++ b/Fiscal/faq_importar_xml.md
@@ -8,13 +8,24 @@ Perguntas frequentes sobre a tela `Importar XML NF-e` (código `204` na pesquisa
 
 ## 📥 Carregamento do XML
 
-### ❓ Onde fica o arquivo `.xml` que devo carregar?
+### ❓ Qual é o fluxo "certo" para lançar uma NF-e que chegou?
+
+**Sempre comece pela Manifestação do Destinatário** (tela `401`), não pelo `Importar XML` direto. Localize a nota no grid da Manifestação, manifeste-a se ainda não foi, e clique no botão **`NF-e`** (entre `Zerar NSU` e `Confirmar`) — a tela `Importar XML` abre automaticamente em inclusão com o XML já carregado.
+
+Abrir o `Importar XML` (F1 → `204`) e clicar em `Novo` é o **caminho excepcional**: serve apenas para XMLs que chegaram por fora da SEFAZ (e-mail, pendrive, outra loja).
+
+### ❓ E quando o XML não veio pela SEFAZ?
 
 Depende da origem:
 
-- **Veio por e-mail/anexo**: salve o `.xml` em uma pasta de fácil acesso (ex.: `Documentos/XMLs/`) e selecione no campo `Caminho`.
-- **Veio da SEFAZ pela Manifestação**: o arquivo já está armazenado no banco do Sol.NET. Use o caminho via [Manifestação do Destinatário](documentacao_manifestacao_destinatario.md) (tela `401`) — a tela `Importar XML` abre com a chave preenchida e busca o XML sozinha.
+- **Veio por e-mail/anexo**: salve o `.xml` em uma pasta de fácil acesso (ex.: `Documentos/XMLs/`) e, na tela `Importar XML` em modo `Novo`, selecione no campo `Caminho` (grupo `Arquivo`).
 - **Veio em pendrive**: copie para o disco local antes de carregar; o seletor aceita qualquer caminho válido.
+
+### ❓ Posso digitar a chave de acesso no campo `Chave de Acesso` para o sistema baixar o XML?
+
+**Não.** O campo `Chave de Acesso` dentro do grupo `Manifesto` é apenas **informativo** — ele exibe a chave do XML já carregado (vindo da Manifestação ou de um arquivo). Não há ação de "baixar XML pela chave" disparada por esse campo.
+
+O caminho para trazer um XML é sempre: ou clicar `NF-e` na Manifestação, ou selecionar o `.xml` no grupo `Arquivo`.
 
 ### ❓ Posso carregar XML de NFC-e (cupom fiscal eletrônico)?
 
@@ -146,7 +157,9 @@ Não. Quando o Sol.NET detecta que o movimento vinculado foi **excluído** ou **
 
 ### ❓ Preciso fazer a Manifestação antes de importar o XML?
 
-Legalmente, **sim**, para NF-e de terceiros emitidas contra o seu CNPJ. A `Confirmação da Operação` ou `Ciência da Emissão` precede o lançamento como entrada. Operacionalmente, o Sol.NET permite carregar um `.xml` diretamente — mas o caminho recomendado é via Manifestação, porque garante que o XML é o oficial da SEFAZ.
+**Sim, é o fluxo padrão.** Para NF-e de terceiros emitidas contra o seu CNPJ, a `Confirmação da Operação` ou `Ciência da Emissão` precede o lançamento como entrada — e o Sol.NET já entrega isso integrado: depois de manifestar, basta clicar no botão `NF-e` (entre `Zerar NSU` e `Confirmar` na tela `401`) e a importação parte do XML que a SEFAZ disponibilizou.
+
+Carregar um `.xml` diretamente pelo `Importar XML` (modo `Novo` + grupo `Arquivo`) existe como **exceção** para situações em que o XML não veio pela SEFAZ. Não substitui a manifestação.
 
 Veja [Manifestação do Destinatário](documentacao_manifestacao_destinatario.md).
 

--- a/Fiscal/guia_rapido_importar_xml.md
+++ b/Fiscal/guia_rapido_importar_xml.md
@@ -2,7 +2,7 @@
 
 ## 🎯 Visão Geral
 
-Cartão de referência para a equipe de suporte durante o atendimento. Para a explicação completa de campos, regras e exemplos, consulte a [Documentação Importar XML](documentacao_importar_xml.md).
+Cartão de referência rápido com a rotina padrão, mensagens de erro e atalhos de combinação de filtros. Para a explicação completa de campos, regras e exemplos, consulte a [Documentação Importar XML](documentacao_importar_xml.md).
 
 > **Tela**: `Importar XML NF-e` — código **`204`** (pesquisa F1).
 
@@ -160,4 +160,4 @@ E ainda:
 
 **Última atualização**: Maio de 2026  
 **Versão**: 1.0  
-**Público-alvo**: Equipe de suporte Sol.NET
+**Público-alvo**: Usuários e administradores do Sol.NET ERP

--- a/Fiscal/guia_rapido_importar_xml.md
+++ b/Fiscal/guia_rapido_importar_xml.md
@@ -140,10 +140,10 @@ E ainda:
 | Tela | Código F1 | Quando ir lá |
 |------|-----------|--------------|
 | `Manifestação do Destinatário` | `401` | Para ver/manifestar NF-e antes de importar. |
-| `Cadastro de Produtos` | `40` | Vincular ou cadastrar produto do item do XML. |
-| `Cadastro de Pessoas` | `30` | Cadastrar fornecedor novo. |
-| `Movimentos de Entrada` | `203` | Onde a entrada gerada pelo `Lançar NF-e` é registrada. |
-| `Cadastro de Empresas` | `100` | Habilitar/desabilitar `Tipo Conferência XML` por loja. |
+| `Cadastro de Produtos` | `32` | Vincular ou cadastrar produto do item do XML. |
+| `Cadastro de Pessoas` | `5` | Cadastrar fornecedor novo. |
+| `Movimentos de Compras` | `201` | Onde a entrada gerada pelo `Lançar NF-e` é registrada. |
+| `Cadastro de Empresas` | `1` | Habilitar/desabilitar `Tipo Conferência XML` por loja. |
 
 ---
 

--- a/Fiscal/guia_rapido_importar_xml.md
+++ b/Fiscal/guia_rapido_importar_xml.md
@@ -8,20 +8,32 @@ Cartão de referência para a equipe de suporte durante o atendimento. Para a ex
 
 ---
 
-## ⚡ Rotina padrão de importação
+## ⚡ Rotina padrão (via Manifestação)
 
-Checklist do fluxo "carregar XML → lançar movimento":
+O caminho normal **começa na Manifestação do Destinatário**, não em `Novo` direto no `Importar XML`.
 
-1. **Abrir a tela**: F1 → `204`.
-2. **Modo de inclusão**: clique em `Novo`.
-3. **Carregar o XML**: aba `XML`, campo `Caminho` → botão de busca → selecione o `.xml`.
-4. **Conferir cabeçalho**: aba `Cabeçalho` — `Descrição da Loja`, `Fornecedor`, `Comportamento` (Entrada/Saída).
-5. **Vincular itens**: aba `Itens` — todos devem aparecer com `Descrição` preenchida. Itens em branco → duplo clique → vincular ou cadastrar.
-6. **Conferir financeiro**: aba `Financeiro` — número, vencimento e valor das parcelas.
-7. **Lançar**: clique em `Lançar NF-e` (botão padrão).
-8. **Confirmar na movimentação**: ajustar tipo de movimento e gravar.
+1. **Abrir a Manifestação**: F1 → `401`.
+2. **Localizar a NF-e** no grid (filtros por loja, fornecedor, período, chave).
+3. **Manifestar** se ainda não foi: `Confirmar(1)` ou `Ciência(4)` conforme o caso.
+4. **Clicar em `NF-e`** (botão entre `Zerar NSU` e `Confirmar`) com a linha selecionada.
+5. O `Importar XML` abre **já em inclusão** e com o XML carregado.
+6. **Conferir cabeçalho**: aba `Cabeçalho` — `Descrição da Loja`, `Fornecedor`, `Comportamento` (Entrada/Saída).
+7. **Vincular itens**: aba `Itens` — todos devem aparecer com `Descrição` preenchida. Itens em branco → duplo clique → vincular ou cadastrar.
+8. **Conferir financeiro**: aba `Financeiro` — número, vencimento e valor das parcelas.
+9. **Lançar**: clique em `Lançar NF-e` (botão padrão).
+10. **Confirmar na movimentação**: ajustar tipo de movimento e gravar.
 
 > 💡 Se a empresa tem conferência XML habilitada, ainda há uma etapa de **conferência física** antes do lançamento. Veja [Conferência de XML](documentacao_conferencia_xml.md).
+
+### Caminho alternativo: XML por arquivo
+
+Apenas quando o XML não veio pela SEFAZ (e-mail, pendrive, outra loja):
+
+1. F1 → `204` → `Novo`.
+2. Aba `XML`, grupo `Arquivo`, campo `Caminho` → botão à direita seleciona o `.xml`.
+3. Demais passos iguais ao fluxo padrão a partir do item 6.
+
+> ⚠️ O campo `Chave de Acesso` no grupo `Manifesto` **não recebe digitação para iniciar uma importação** — ele apenas mostra a chave do XML já carregado.
 
 ---
 

--- a/Fiscal/guia_rapido_importar_xml.md
+++ b/Fiscal/guia_rapido_importar_xml.md
@@ -1,0 +1,151 @@
+# 📄 Guia Rápido — Importar XML NF-e - Sol.NET
+
+## 🎯 Visão Geral
+
+Cartão de referência para a equipe de suporte durante o atendimento. Para a explicação completa de campos, regras e exemplos, consulte a [Documentação Importar XML](documentacao_importar_xml.md).
+
+> **Tela**: `Importar XML NF-e` — código **`204`** (pesquisa F1).
+
+---
+
+## ⚡ Rotina padrão de importação
+
+Checklist do fluxo "carregar XML → lançar movimento":
+
+1. **Abrir a tela**: F1 → `204`.
+2. **Modo de inclusão**: clique em `Novo`.
+3. **Carregar o XML**: aba `XML`, campo `Caminho` → botão de busca → selecione o `.xml`.
+4. **Conferir cabeçalho**: aba `Cabeçalho` — `Descrição da Loja`, `Fornecedor`, `Comportamento` (Entrada/Saída).
+5. **Vincular itens**: aba `Itens` — todos devem aparecer com `Descrição` preenchida. Itens em branco → duplo clique → vincular ou cadastrar.
+6. **Conferir financeiro**: aba `Financeiro` — número, vencimento e valor das parcelas.
+7. **Lançar**: clique em `Lançar NF-e` (botão padrão).
+8. **Confirmar na movimentação**: ajustar tipo de movimento e gravar.
+
+> 💡 Se a empresa tem conferência XML habilitada, ainda há uma etapa de **conferência física** antes do lançamento. Veja [Conferência de XML](documentacao_conferencia_xml.md).
+
+---
+
+## 🔘 Os três botões "Lançar"
+
+| Botão | Quando usar |
+|-------|-------------|
+| **`Lançar NF-e`** | 95% dos casos — entrada de fornecedor com tudo conforme a nota. |
+| **`Lançar Parcial`** | Só parte da mercadoria chegou. Marque os itens recebidos e ajuste quantidades antes. |
+| **`Lançar Próprio`** | NF-e em que a empresa é a **emitente** (Emissão = `PROPRIA`). Bloqueado para terceiros. |
+
+E ainda:
+
+| Botão | O que faz |
+|-------|-----------|
+| **`DANFE`** | Imprime o documento auxiliar a partir do XML (pelo grid ou pelo cadastro). |
+
+---
+
+## 📊 Combos de status — referência rápida
+
+### Filtro `Status`
+
+| Código | Texto | Significa |
+|--------|-------|-----------|
+| `0` | `Edição` | XML carregado mas com pendência (ex.: itens não vinculados). |
+| `1` | `Finalizado` | Pronto para virar movimento. |
+| `2` | `Importado` | Já gerou movimento na entrada/saída. |
+
+### Filtro `Status Conferência`
+
+| Texto exibido | Significa |
+|---------------|-----------|
+| `Não Conferido` | Conferência não iniciada. |
+| `Em Andamento` | Conferência aberta, mas ainda não finalizada. |
+| `Finalizada Sem Divergência` | Tudo bateu com o XML. |
+| `Finalizada Com Divergência` | Conferente registrou diferença — exige atenção antes de lançar. |
+
+### Filtro `Emissão`
+
+| Código | Texto |
+|--------|-------|
+| `0` | `PROPRIA` (empresa emitiu o XML) |
+| `1` | `TERCEIRO` (fornecedor emitiu) |
+
+### Filtro `Financeiro` no grid
+
+| Texto | Significa |
+|-------|-----------|
+| `LANÇADO` | Já gerou contas a pagar/receber. |
+| `NÃO LANÇADO` | XML importado mas sem financeiro gerado. |
+
+---
+
+## 🛒 Vincular item — fluxo mínimo
+
+1. **Duplo clique** na linha do item sem descrição.
+2. O `Cadastro de Produtos` abre em pesquisa.
+3. Localize o produto **ou** vá para inclusão para criar novo.
+4. Confirme — o vínculo é gravado. **Próxima compra do mesmo produto com o mesmo fornecedor já entra vinculado.**
+
+### Bloqueios que aparecem
+
+| Mensagem | Por quê |
+|----------|---------|
+| `Não Permitido, Tipo Serviço!` | Produto selecionado é serviço — XML de mercadoria não vincula. |
+| `Não Permitido, Produto configurado para desagregação!` | Produto tem fluxo próprio. |
+| `Não Permitido, Vinculo de produto linkado!` | Configuração geral proíbe vincular produtos linkados. |
+| `Produto Linkado Selecionado!` (aviso) | Vínculo permitido, mas chama atenção do usuário. |
+| `Pessoa não cadastrada!` | Fornecedor do XML ainda não está no cadastro de pessoas. |
+
+---
+
+## ❌ Mensagens de erro no carregamento
+
+| Mensagem | Resolução |
+|----------|-----------|
+| `Arquivo XML Inválido!` | Arquivo corrompido / não é NF-e / esquema errado. Pedir novo XML. |
+| `Chave de Acesso já Cadastrada!` | XML já foi carregado antes — localizar registro existente. |
+| `( razão ) NÃO É SUA EMPRESA!` | CNPJ destinatário não bate com loja. Conferir loja correta. |
+| `Não Existe Nenhum Item com Vinculo!` | Tentou lançar com itens não vinculados. Voltar e vincular. |
+| `Existem produtos linkados vinculados!` | Configuração proíbe — revisar a vinculação. |
+| `Não Permitido! Somente Emissão PROPRIA.` | Usou `Lançar Próprio` em NF-e de terceiro. Trocar para `Lançar NF-e`. |
+| `Movimentação Cancelada! Lançar NF-e Novamente.` | Vínculo antigo apontava para movimento cancelado. O sistema desfaz o vínculo automaticamente. |
+| `Movimentação Excluida! Lançar NF-e Novamente.` | Idem, mas para movimento excluído. |
+
+---
+
+## 🔍 Combinações úteis de filtros
+
+| Objetivo | Como filtrar |
+|----------|--------------|
+| XMLs ainda não lançados | `Status` = `Edição` ou `Finalizado` |
+| XMLs sem financeiro | 2ª guia → `Financeiro` = `Não Lançados` |
+| Notas de uma loja específica no mês | `Descrição da Loja` + `Data` = `Emissão` + intervalo |
+| Buscar por chave de acesso | `Campo a pesquisar` = `Chave de Acesso` + `Condição` = `=` + colar a chave |
+| Notas com divergência de conferência | `Status Conferência` = `Finalizada Com Divergência` |
+| XMLs de saída próprios | 2ª guia → `Operações` = `Externas` |
+
+---
+
+## 🔗 Atalhos para outras telas
+
+| Tela | Código F1 | Quando ir lá |
+|------|-----------|--------------|
+| `Manifestação do Destinatário` | `401` | Para ver/manifestar NF-e antes de importar. |
+| `Cadastro de Produtos` | `40` | Vincular ou cadastrar produto do item do XML. |
+| `Cadastro de Pessoas` | `30` | Cadastrar fornecedor novo. |
+| `Movimentos de Entrada` | `203` | Onde a entrada gerada pelo `Lançar NF-e` é registrada. |
+| `Cadastro de Empresas` | `100` | Habilitar/desabilitar `Tipo Conferência XML` por loja. |
+
+---
+
+## 🧭 Diagnóstico rápido
+
+| Sintoma | Verificar |
+|---------|-----------|
+| "Botão `Lançar NF-e` está desabilitado" | Está em modo de visualização — entrar no registro pelo grid e abrir para edição. |
+| "Não estou vendo a aba `Conferência`" | Empresa não tem `Tipo Conferência XML` ativo. Configurar no `Cadastro de Empresas`. |
+| "Vinculei errado um produto" | Abrir o item (duplo clique), o vínculo pode ser refeito enquanto o XML estiver em `Edição`. |
+| "Lancei a NF-e mas o estoque não subiu" | A entrada na movimentação não foi gravada — abrir o registro `204`, ver se aparece `Importado` e qual o `ID Movimento`. |
+
+---
+
+**Última atualização**: Maio de 2026  
+**Versão**: 1.0  
+**Público-alvo**: Equipe de suporte Sol.NET

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -483,6 +483,17 @@
                   </ul>
                 </details>
               </li>
+              <li class="sn-sidebar__subgroup-item">
+                <details class="sn-sidebar__subgroup" data-sn-subgroup="importar-xml">
+                  <summary class="sn-sidebar__subgroup-summary">Importar XML NF-e</summary>
+                  <ul class="sn-sidebar__subitems">
+                    <li><a href="{{ '/Fiscal/documentacao_importar_xml/' | relative_url }}">Documentação</a></li>
+                    <li><a href="{{ '/Fiscal/guia_rapido_importar_xml/' | relative_url }}">Guia Rápido</a></li>
+                    <li><a href="{{ '/Fiscal/faq_importar_xml/' | relative_url }}">FAQ</a></li>
+                    <li><a href="{{ '/Fiscal/documentacao_conferencia_xml/' | relative_url }}">Conferência de XML</a></li>
+                  </ul>
+                </details>
+              </li>
             </ul>
           </details>
 


### PR DESCRIPTION
## Resumo

Cria a documentação da tela **Importar XML NF-e** (código `204` na pesquisa F1) e um documento dedicado ao fluxo de **Conferência de XML**, ambos no módulo Fiscal.

## Arquivos criados

- `Fiscal/documentacao_importar_xml.md` — referência completa (consulta, importação, sub-abas, vínculo de itens, lançamento)
- `Fiscal/guia_rapido_importar_xml.md` — checklist operacional para suporte
- `Fiscal/faq_importar_xml.md` — perguntas frequentes
- `Fiscal/documentacao_conferencia_xml.md` — fluxo da conferência física (habilitação por loja, estados, aba `Conferência`, reabertura, interação com lançamento)

## Arquivos alterados

- `Fiscal/README.md` — novas seções no índice e versão para 1.2
- `Fiscal/documentacao_manifestacao_destinatario.md` — link cruzado para a nova doc de Importar XML
- `_layouts/default.html` — novo subgrupo `Importar XML NF-e` na barra lateral, sob 🏛️ Fiscal

## Códigos de tela referenciados

- `204` — `Importar XML NF-e` (confirmado em `FORMULARIO`)
- `220` — `Conferência Pedido` (mencionado para fluxos auxiliares)
- `401` — Manifestação do Destinatário (referência cruzada)
- `40`, `30`, `100`, `203` — citados como atalhos para outras telas

## Fontes usadas

- `Sol.NET/FormEspecias/uFrmImportarXML.dfm` e `.pas` no repositório `hetosoft/ProjetosSol.NET` (branch `develop`)
- `Sol.NET/FormEspecias/Fiscal/uFrmManifestacao.pas` — invocação cruzada
- Consulta direta às tabelas `FORMULARIO` e `IMPORTARXML_CABECARIO` no banco Concordia

## Test plan

- [ ] Verificar que os 4 documentos novos abrem pela barra lateral em mobile e desktop
- [ ] Confirmar que o subgrupo `Importar XML NF-e` aparece dentro de 🏛️ Fiscal
- [ ] Conferir links internos (`Manifestação do Destinatário ↔ Importar XML ↔ Conferência de XML`)
- [ ] Verificar que tabelas renderizam com o estilo do portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)