### PR TITLE
docs: cria documentação da Integração de Pedidos iFood (módulo Integrações)

### DIFF
--- a/Integracoes/README.md
+++ b/Integracoes/README.md
@@ -1,0 +1,44 @@
+---
+title: "Índice: Integrações Sol.NET"
+permalink: /Integracoes/
+---
+# 🔌 Índice: Integrações Sol.NET
+
+Aqui ficam os documentos das **integrações** entre o Sol.NET e plataformas externas — sistemas de pedidos, marketplaces, gateways e demais canais que se conectam ao ERP para trocar pedidos, produtos, preços ou status.
+
+Cada integração tem sua própria pasta com os documentos no padrão do portal: **Documentação**, **Guia Rápido** e **FAQ**.
+
+---
+
+## 📋 Integrações Disponíveis
+
+### 🍔 **[iFood — Pedidos](iFood/README.md)**
+Captura automática de pedidos do iFood, separação no balcão e geração do movimento de venda no Sol.NET.
+
+- Configuração na aba `iFood` do `Cadastro de Empresas` (código `1`)
+- Captura em background pelo `Sol.NET Monitor de Integração`
+- Operação no `Monitor de Pedidos iFood` (código `151`): Aceitar → Iniciar Preparação → Pronto p/ Retirada → Finalizar Separação
+- Recusa com motivo vindo da API do iFood
+- Ajuste de quantidade e exclusão de item por ruptura, com sincronização para o iFood
+- Vínculo manual de produto quando o código externo do iFood não bate com o `Cadastro de Produtos`
+- Tratamento de cancelamento e disputa originados do próprio iFood
+
+---
+
+## 🎯 Por onde começar
+
+### **🆕 Preparando uma empresa para receber pedidos iFood**
+1. Confirme com a Hetosoft que a licença **SAC iFood** está ativa para a empresa
+2. Configure a aba `iFood` em `Cadastro de Empresas` (código `1`) — veja a [Documentação de Pedidos iFood](iFood/documentacao_pedidos_ifood.md)
+3. Garanta que o `Sol.NET Monitor de Integração` esteja em execução no servidor
+4. Treine o atendente no `Monitor de Pedidos iFood` (código `151`) usando o [Guia Rápido](iFood/guia_rapido.md)
+
+### **⚡ Operando o fluxo do dia a dia**
+1. Use o [Guia Rápido — Pedidos iFood](iFood/guia_rapido.md) como cartão de referência
+2. Consulte o [FAQ — Pedidos iFood](iFood/faq.md) quando algo travar
+
+---
+
+**📅 Última atualização**: Maio de 2026  
+**📦 Versão**: 1.0  
+**🎯 Público-alvo**: Usuários do Sol.NET e atendentes de balcão

--- a/Integracoes/iFood/README.md
+++ b/Integracoes/iFood/README.md
@@ -1,0 +1,44 @@
+---
+title: "Índice: Integração de Pedidos iFood"
+permalink: /Integracoes/iFood/
+---
+# 🍔 Índice: Integração de Pedidos iFood
+
+A integração com o iFood permite que pedidos feitos no aplicativo do iFood entrem **automaticamente** no Sol.NET, sejam **separados pelo atendente** e gerem um **movimento de venda** sem que seja preciso digitar nada manualmente.
+
+---
+
+## 📋 Documentos Disponíveis
+
+### 📖 **[Documentação completa](documentacao_pedidos_ifood.md)**
+Referência detalhada da integração: pré-requisitos, configuração na empresa, processo automático de captura, fluxo de aceite/separação/finalização no monitor, recusa com motivo, tratamento de cancelamentos e disputas vindos do iFood, criação do movimento e responsabilidade pela finalização financeira.
+
+### 🚀 **[Guia Rápido](guia_rapido.md)**
+Cartão de operação do atendente no `Monitor de Pedidos iFood`. Lista os botões, as cores das linhas e o passo-a-passo do recebimento até a finalização da separação.
+
+### ❓ **[FAQ — Perguntas Frequentes](faq.md)**
+Respostas curtas para problemas que aparecem no atendimento: pedido que não chega, item sem vínculo, ruptura de estoque, pedido cancelado pelo cliente, "Consumidor iFood" no movimento, dúvidas sobre o financeiro.
+
+---
+
+## 🎯 Por onde começar
+
+### **🆕 Primeira vez configurando iFood para a sua loja**
+1. Confirme a licença **SAC iFood** com a Hetosoft
+2. Siga a seção **Pré-requisitos e Configuração** da [Documentação completa](documentacao_pedidos_ifood.md)
+3. Coloque o `Sol.NET Monitor de Integração` para rodar no servidor
+4. Treine o atendente com o [Guia Rápido](guia_rapido.md)
+
+### **🛎️ Atendente operando o monitor**
+1. Tenha o [Guia Rápido](guia_rapido.md) à mão durante o turno
+2. Quando travar, consulte o [FAQ](faq.md)
+
+### **🔍 Algo não funcionou como esperado**
+1. Comece pelo [FAQ](faq.md) — a maioria das dúvidas está lá
+2. Para o panorama da integração e dos status, vá direto à [Documentação completa](documentacao_pedidos_ifood.md)
+
+---
+
+**📅 Última atualização**: Maio de 2026  
+**📦 Versão**: 1.0  
+**🎯 Público-alvo**: Usuários do Sol.NET e atendentes de balcão

--- a/Integracoes/iFood/documentacao_pedidos_ifood.md
+++ b/Integracoes/iFood/documentacao_pedidos_ifood.md
@@ -1,0 +1,415 @@
+# 📄 Integração de Pedidos iFood - Sol.NET
+
+## 🎯 Visão Geral
+
+A **Integração de Pedidos iFood** conecta o Sol.NET diretamente à API do iFood para receber, processar e faturar pedidos do aplicativo **sem digitação manual**. A integração funciona em duas pontas que trabalham juntas:
+
+1. **Captura automática** — o `Sol.NET Monitor de Integração` consulta a API do iFood a cada poucos minutos, identifica novos pedidos e os grava no banco do Sol.NET.
+2. **Operação do balcão** — o atendente abre a tela `Monitor de Pedidos iFood` (código `151`), aceita o pedido, faz a separação dos itens e finaliza, gerando um movimento de venda no Sol.NET.
+
+### Principais características:
+
+- ✅ Captura contínua dos pedidos enquanto o monitor de integração está rodando
+- ✅ Aceite manual (atendente clica em `Aceitar Pedido`) ou automático (sistema confirma sozinho na API ao receber)
+- ✅ Fluxo de separação com status visíveis (Aguardando → Confirmado → Em Preparação → Pronto p/ Retirada)
+- ✅ Exclusão de item por ruptura de estoque, com baixa automática no iFood
+- ✅ Ajuste de quantidade do item, sincronizado com o iFood
+- ✅ Vínculo manual de produto quando o código externo do iFood não bate com o `Cadastro de Produtos`
+- ✅ Recusa com motivos oficiais do iFood
+- ✅ Tratamento automático de cancelamentos e disputas iniciados pelo próprio cliente no app
+- ✅ Geração do movimento de venda já com itens e pessoa associada
+- ✅ Funciona por empresa: cada empresa do Sol.NET pode ter seu próprio Merchant ID iFood
+
+---
+
+## 🛠️ Pré-requisitos
+
+Antes de qualquer configuração, garanta que:
+
+- ✅ A empresa possui a **licença SAC iFood** ativa na Hetosoft. Sem ela, o processo de captura ignora a empresa e registra que a licença não foi encontrada.
+- ✅ A empresa tem o **Merchant ID iFood** preenchido na aba `iFood` do `Cadastro de Empresas` (código `1`). Esse identificador vem do próprio iFood e é o que liga aquela empresa à conta do restaurante no app.
+- ✅ Os **produtos vendidos no iFood** já estão cadastrados no `Cadastro de Produtos` (código `32`) e sincronizados com o iFood. A integração faz o vínculo pelo campo `Código` do produto.
+- ✅ Existe um **Tipo de Movimento** apropriado no `Cadastro de Tipos de Movimento` para representar a venda iFood (escolha do tipo determina toda a regra contábil e financeira do movimento gerado — ver seção [Movimento gerado](#-movimento-gerado)).
+- ✅ O **`Sol.NET Monitor de Integração`** está instalado e configurado para rodar no servidor da loja, com o `iFood` registrado entre os processos de e-commerce.
+- ✅ As tabelas internas da integração já foram criadas (atualização automática do banco no primeiro `Sol.NET` aberto após receber a versão com iFood — `IFOOD_PEDIDOS`, `IFOOD_EVENTOS`, `IFOOD_PEDIDO_ITENS` e as colunas `IFOOD_*` em `EMPRESAS`).
+
+---
+
+## ⚙️ Configuração no Cadastro de Empresas
+
+A configuração da integração mora no `Cadastro de Empresas` (código `1`), dentro da aba **`iFood`**.
+
+> ⚠️ **Acesso de suporte necessário:** alterações no `Cadastro de Empresas` requerem permissão de acesso de suporte. Entre em contato com o suporte Hetosoft antes de realizar qualquer modificação nesta tela.
+
+Para cada empresa que vai receber pedidos do iFood, preencha (além dos campos do iFood que já existiam — Merchant ID, tabela de preço, estoque mínimo):
+
+### `Tipo de Movimento`
+Tipo de movimento que será criado quando o pedido for finalizado. Lista somente tipos **ativos** do `Cadastro de Tipos de Movimento`. **Obrigatório** para que o pedido consiga ser finalizado — sem isso, a tela bloqueia a criação do movimento.
+
+> ⚠️ **Acesso de suporte necessário:** alterações no `Cadastro de Tipos de Movimento` requerem permissão de acesso de suporte. Entre em contato com o suporte Hetosoft antes de realizar qualquer modificação nesta tela.
+
+A escolha do tipo de movimento define **toda** a regra contábil, fiscal e financeira da venda — emissão de NFC-e, geração de contas a receber, baixa de estoque, comissão. Use sempre um tipo específico para iFood, separado dos tipos de balcão, para facilitar relatórios.
+
+### `Confirmação`
+Define como o sistema sinaliza o aceite ao iFood:
+
+- **`Manual`** (padrão recomendado) — o pedido entra no `Monitor de Pedidos iFood` em status **`Aguardando`** e fica parado até o atendente clicar em `Aceitar Pedido`. Só nesse momento o Sol.NET responde "aceito" ao iFood. Use para lojas onde o atendente precisa ter o controle do que entra (estoque crítico, hora de pico, conferência humana).
+- **`Automático`** — assim que o pedido chega ao Sol.NET pelo processo de captura, o sistema **já confirma no iFood automaticamente** e marca o pedido como **`Em Preparação`** no monitor (linha azul). Ele pula tanto o `Aceitar Pedido` quanto o `Iniciar Preparação` — o atendente entra direto na etapa de separação. Use quando a operação não precisa de camada manual de aprovação e a cozinha pode começar o preparo automaticamente.
+
+A separação dos itens, a sinalização de pronto para retirada e a finalização **continuam manuais** independentemente desta configuração.
+
+---
+
+## 🔄 Captura automática de pedidos
+
+A captura roda no aplicativo **`Sol.NET Monitor de Integração`** — uma aplicação à parte do Sol.NET principal, que fica em execução contínua no servidor.
+
+### Como funciona
+Em ciclos regulares, o monitor de integração:
+
+1. Lê a lista de empresas com `Merchant ID iFood` preenchido e licença SAC iFood válida.
+2. Para cada empresa, pergunta à API do iFood se há eventos novos (pedido novo, cancelado, em disputa).
+3. Grava cada pedido inédito na tabela interna do Sol.NET (com o JSON completo da API), evita duplicação por chave única.
+4. Avisa o iFood que recebeu os eventos (`acknowledgment`) para que eles não venham novamente.
+5. Para pedidos novos: se a empresa está configurada como `Confirmação Automática`, já chama a API para confirmar; caso contrário, deixa o pedido em status **`Aguardando`** esperando ação do atendente.
+6. Para cancelamentos vindos do iFood: marca o pedido como `CANCELLED` no banco e, se o movimento já tinha sido gerado, cancela o movimento e suas parcelas (ver [Cancelamentos e disputas](#-cancelamentos-e-disputas-vindos-do-ifood)).
+
+### Visualizar e forçar uma rodada de captura
+
+No `Sol.NET Monitor de Integração`, na área de log dos processos, o atendente encontra o processo **`Pedidos IFood`** rodando junto dos demais processos de e-commerce (Tray, WBuy, MercadApp). Para forçar uma rodada imediata sem esperar o próximo ciclo:
+
+1. No `Sol.NET Monitor de Integração`, clique com o botão direito sobre a janela de log
+2. No menu de contexto, escolha **`eCommerce → Pedidos IFood`**
+3. O processo executa imediatamente para todas as empresas configuradas
+
+Use a execução manual quando o atendente acabou de fazer um pedido teste pelo app e quer ver o efeito no monitor sem esperar.
+
+### Se o processo parar
+Se o `Sol.NET Monitor de Integração` for fechado ou der erro, **a captura para**. Os pedidos seguem entrando no iFood, mas não chegam ao Sol.NET até o monitor voltar — e quando voltar, ele puxa o atraso de uma vez. Por isso é parte do checklist de abertura de loja **garantir que o monitor de integração está em execução** antes de receber o primeiro pedido do dia.
+
+---
+
+## 🖥️ Monitor de Pedidos iFood (código 151)
+
+A tela principal de operação é o **`Monitor de Pedidos iFood`** — código `151` na pesquisa F1.
+
+### Layout da tela
+
+A tela é dividida em três áreas verticais:
+
+1. **Barra de ações** (topo) — botões coloridos do fluxo (`Atualizar`, `Aceitar Pedido`, `Recusar Pedido`, `Iniciar Preparação`, `Pronto p/ Retirada`, `Finalizar Separação`) e o filtro **`Data:`** que define qual dia mostrar no grid.
+2. **Grid de pedidos** (centro-topo) — um pedido por linha, com **`Código`** (o short code do iFood), **`Empresa`**, **`Status`**, **`Tipo`** (entrega ou retirada), **`Total`**, **`Data`**, **`Hora`** e **`Observação`**.
+3. **Painel de itens** (centro-baixo) — barra com `Vincular Produto`, `Ajustar Quantidade` e `Excluir Item (Ruptura)`, abaixo o grid de itens do pedido selecionado com **`Item`**, **`Produto (Sistema)`**, **`Vinculado`**, **`Qtd. Original`**, **`Qtd. Ajustada`**, **`Preço Unit.`**, **`Excluído`** e **`Obs.`**.
+4. **Painel de detalhe** (rodapé) — recapitula `Código`, `Status`, `Tipo`, `Total`, `Empresa` e `Observação` do pedido selecionado.
+
+### Filtro por data
+
+O `Monitor de Pedidos iFood` carrega por padrão os pedidos **do dia atual**. Para conferir pedidos de outros dias (revisão, conferência fiscal, auditoria), altere a data no campo `Data:` no topo da tela — o grid recarrega automaticamente assim que a data muda.
+
+### Cores no grid de pedidos
+
+A cor da linha indica em que ponto do fluxo o pedido está:
+
+- 🟡 **Amarelo** — pedido em status **`Aguardando`** (precisa de aceite do atendente)
+- 🔵 **Azul** — pedido em status **`Em Preparação`** (separação em andamento)
+- ⚪ **Branco / padrão** — outros status (já confirmado e aguardando preparação, pronto p/ retirada, cancelado, etc.)
+
+### Cores no grid de itens
+
+- 🔴 **Vermelho** — item sem vínculo de produto. **Não dá para aceitar nem finalizar o pedido enquanto houver linhas vermelhas.**
+- ⚪ **Cinza com tachado** — item excluído por ruptura. Ignorado no momento da finalização.
+
+---
+
+## 🔁 Fluxo passo-a-passo (operação do atendente)
+
+O ciclo de um pedido iFood no monitor tem cinco etapas. Cada etapa só fica disponível quando a anterior foi concluída — o sistema habilita os botões em sequência.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Aguardando : empresa Manual<br/>(pedido capturado)
+    [*] --> EmPreparacao : empresa Automático<br/>(pula Aceitar e Iniciar Preparação)
+    Aguardando --> Confirmado : Aceitar Pedido
+    Aguardando --> Cancelado : Recusar Pedido
+    Confirmado --> EmPreparacao : Iniciar Preparação
+    EmPreparacao --> ProntoParaRetirada : Pronto p/ Retirada
+    EmPreparacao --> Finalizado : Finalizar Separação
+    ProntoParaRetirada --> Finalizado : Finalizar Separação
+    Finalizado --> [*] : movimento gerado
+    Cancelado --> [*]
+```
+
+### 1️⃣ Receber o pedido
+
+O pedido entra no monitor com linha **amarela** (`Aguardando`). O painel de itens carrega automaticamente quando o pedido é selecionado. Confira:
+
+- Itens do pedido (coluna `Item`)
+- Vínculo com produto do sistema (coluna `Vinculado` — se algum item estiver **vermelho/sem vínculo**, resolva isso antes de aceitar; veja [Vincular produto](#-vincular-produto))
+- Observação do cliente (painel de detalhe)
+
+### 2️⃣ Aceitar (ou recusar)
+
+Com um pedido **`Aguardando`** selecionado, dois botões ficam habilitados:
+
+- **`Aceitar Pedido`** (verde) — confirma o pedido na API do iFood **antes** de gravar no banco. Se a API rejeitar (credencial vencida, pedido já cancelado pelo cliente), a tela avisa e nada é alterado. Em sucesso, o status muda para **`Confirmado`** e a linha sai do amarelo.
+- **`Recusar Pedido`** (vermelho) — abre a [tela de motivo de recusa](#-recusar-pedido). Veja a seção dedicada abaixo.
+
+Se a empresa estiver com `Confirmação = Automático` no Cadastro de Empresas, o pedido **chega já em `Em Preparação`** (linha azul) — as etapas de Aceitar Pedido e Iniciar Preparação não aparecem no fluxo; o atendente entra direto na separação (passo 4 deste guia).
+
+### 3️⃣ Iniciar Preparação
+
+Com um pedido **`Confirmado`** selecionado, o botão **`Iniciar Preparação`** (âmbar) fica habilitado. Ao clicar:
+
+- O Sol.NET avisa o iFood que a preparação começou (a tela do cliente no app passa a mostrar "Seu pedido está sendo preparado")
+- O pedido vai para o status **`Em Preparação`** — a linha fica **azul** no grid
+- Os botões de **manipulação de itens** (Vincular Produto, Ajustar Quantidade, Excluir Item) **só ficam disponíveis a partir daqui**
+
+Use essa etapa para sinalizar à cozinha/separação que pode começar o preparo.
+
+### 4️⃣ Ajustar itens durante a separação
+
+Durante a separação, antes de finalizar, o atendente pode:
+
+#### 🔗 Vincular produto
+Quando um item do pedido vem **sem vínculo** (linha vermelha — o código que o iFood mandou não bate com nenhum produto do `Cadastro de Produtos`):
+
+1. Selecione o item vermelho
+2. Clique em **`Vincular Produto`**
+3. Digite o `Código` ou o `ID` do produto certo no Sol.NET
+4. O sistema valida (o produto precisa existir) e grava o vínculo
+
+Pedidos com itens sem vínculo **não podem ser aceitos nem finalizados**. Resolva o vínculo, ou exclua o item por ruptura.
+
+#### ⚖️ Ajustar quantidade
+Quando o cliente pediu 3 e o estoque só permite servir 2:
+
+1. Selecione o item
+2. Clique em **`Ajustar Quantidade`**
+3. Digite a nova quantidade (precisa ser maior que zero — para "remover", use Excluir Item)
+4. O Sol.NET avisa o iFood; o app do cliente mostra a nova quantidade
+5. A coluna `Qtd. Ajustada` no grid de itens recebe o valor
+
+A quantidade ajustada é o que vai para o movimento final (não a original do pedido).
+
+#### ❌ Excluir item (ruptura)
+Quando o item simplesmente não pode ser entregue (acabou no estoque, fornecedor não trouxe):
+
+1. Selecione o item
+2. Clique em **`Excluir Item (Ruptura)`**
+3. Confirme com o atendente
+4. O Sol.NET avisa o iFood; o app do cliente é atualizado e tipicamente reembolsa o valor do item
+5. O item fica **cinza com tachado** no grid e é **ignorado** no momento da finalização
+
+> ℹ️ Esses ajustes só são possíveis enquanto o pedido está **`Em Preparação`**. Depois de **`Pronto p/ Retirada`** os botões ficam desabilitados.
+
+### 5️⃣ Pronto para Retirada
+
+Quando a separação está completa e o pedido aguarda o entregador/cliente, clique em **`Pronto p/ Retirada`** (azul). O Sol.NET avisa o iFood (no app do cliente aparece "Saiu para entrega"/"Pronto para retirada") e o status vai para **`Pronto`**.
+
+Esse passo é **opcional do ponto de vista do Sol.NET** — `Finalizar Separação` pode ser chamado direto a partir de `Em Preparação`. Mas o uso correto melhora a comunicação com o cliente final no app.
+
+### 6️⃣ Finalizar Separação
+
+Com o pedido em `Em Preparação` ou `Pronto`, o botão **`Finalizar Separação`** (azul) fica disponível. Ao clicar:
+
+1. O sistema **confere se todos os itens estão vinculados** — se houver vermelho, mostra a lista de itens problemáticos e bloqueia
+2. Pede confirmação ("Finalizar separação do pedido X e gerar o movimento?")
+3. Lê os dados do cliente do JSON do pedido (CPF/CNPJ + nome)
+4. Resolve/cria a pessoa no `Cadastro de Pessoas` (ver [Resolução do cliente](#-resolução-do-cliente-pessoa))
+5. **Cria o movimento de venda** no Sol.NET usando o `Tipo de Movimento iFood` configurado para a empresa, com os itens **não excluídos** e suas quantidades efetivas (ajustadas, quando aplicável)
+6. Vincula o `ID_MOVIMENTO` ao pedido na tabela interna
+
+A partir desse ponto, o pedido **já é uma venda no Sol.NET** e pode ser tratado como qualquer outro movimento.
+
+---
+
+## 🚫 Recusar pedido
+
+Com um pedido **`Aguardando`** selecionado, clique em **`Recusar Pedido`** (vermelho). A tela `Recusar Pedido iFood` abre com:
+
+- **Combo `Motivo *`** — lista de motivos **vindos da própria API do iFood** (não é uma lista fixa do Sol.NET; depende do que o iFood retorna naquele momento para aquele pedido). O motivo é **obrigatório**.
+- **Campo `Descrição adicional`** — texto livre, **opcional**, para explicar mais. Útil quando o motivo da API é genérico e o atendente quer registrar o contexto.
+- Botões **`Ok`** e **`Cancelar`**.
+
+Ao clicar em `Ok`:
+
+1. O Sol.NET chama a API do iFood para cancelar o pedido com o código de motivo selecionado
+2. Em sucesso, marca o pedido como `Cancelado` no banco
+3. Se a API rejeitar (motivo inválido, pedido já recusado), o atendente recebe um aviso e nada é gravado
+
+Pedidos `Aguardando` sem ação do atendente **não são automaticamente recusados** — eles continuam aparecendo no monitor. Para limpar o painel é preciso aceitar ou recusar conscientemente.
+
+---
+
+## 👤 Resolução do cliente (pessoa)
+
+Quando o pedido é finalizado, o Sol.NET precisa associá-lo a uma `Pessoa` para conseguir gerar o movimento. A resolução segue esta lógica:
+
+1. **Se o pedido traz CPF (11 dígitos) ou CNPJ (14 dígitos)** no JSON do iFood, o Sol.NET procura uma pessoa cadastrada com aquele documento:
+   - **Encontrou** → usa essa pessoa.
+   - **Não encontrou** → cria uma **pessoa mínima** automaticamente, contendo nome (vindo do iFood) e documento. Demais campos ficam vazios e podem ser completados depois no `Cadastro de Pessoas` (código `5`) se a empresa precisar.
+2. **Se o pedido não traz documento** (cliente comprou no iFood sem CPF na nota), o Sol.NET usa o nome **"Consumidor iFood"** e cria/usa uma pessoa genérica para representar a venda. Isso permite faturar mesmo sem identificação do consumidor final.
+
+A pessoa criada/usada aparece normalmente no movimento gerado, então o relatório de vendas por cliente conta com ela como qualquer outra pessoa.
+
+---
+
+## 💰 Movimento gerado
+
+O `Finalizar Separação` cria um movimento de venda no Sol.NET com:
+
+- **Tipo de Movimento** = o configurado na aba `iFood` do `Cadastro de Empresas`
+- **Empresa** = a empresa do pedido (a que recebeu pelo Merchant ID)
+- **Pessoa** = resolvida conforme a seção anterior
+- **Itens** = somente os **não excluídos**, com a **quantidade efetiva** (ajustada quando houver) e o preço unitário do pedido
+- **Data de emissão** = a data corrente
+- **Estado** = movimento **em aberto** (não finalizado automaticamente)
+
+### Responsabilidade pela finalização financeira
+
+O movimento entra **em aberto**. **Toda regra contábil e financeira do que vai acontecer com esse movimento — geração de NFC-e, baixa de estoque, conta a receber, comissão, classificação fiscal — está definida no `Tipo de Movimento`** escolhido na aba `iFood` do `Cadastro de Empresas`.
+
+Por isso, configure o tipo de movimento iFood com cuidado:
+
+- Se o tipo está configurado para **finalizar automaticamente** (emitir NFC-e, gerar contas a receber, baixar estoque), tudo isso acontece já no momento do `Finalizar Separação` no monitor.
+- Se o tipo deixa o movimento aberto para conferência manual, o atendente/financeiro precisa abrir o movimento na tela `Vendas` (código `202`) e finalizá-lo normalmente.
+
+A integração **não impõe** um modo nem outro — ela respeita o tipo de movimento configurado. Quando estiver implantando iFood em um cliente novo, alinhe com ele qual o comportamento esperado e configure o tipo de acordo.
+
+---
+
+## 🔁 Cancelamentos e disputas vindos do iFood
+
+Nem todo cancelamento parte da loja. O cliente pode cancelar pelo app, e o iFood pode abrir uma disputa por reclamação. Esses eventos chegam ao Sol.NET pelo mesmo processo de captura.
+
+### Cancelamento iniciado pelo cliente/iFood
+
+Quando o iFood envia um evento de cancelamento (`CANCELLED`, `ORDER_CANCELLED` ou `CANCELLATION_REQUEST`):
+
+1. O pedido é marcado como **`Cancelado`** no banco
+2. **Se o movimento já tinha sido gerado** (`Finalizar Separação` já tinha sido feito), o Sol.NET **cancela o movimento** automaticamente **e também as parcelas a receber** ligadas a ele — desfaz o efeito financeiro
+3. **Se o movimento ainda não tinha sido gerado**, basta marcar o pedido — não há nada a desfazer
+
+O atendente nota o cancelamento porque o pedido some das linhas amarelas/azuis do monitor (ou aparece com status `Cancelado` no filtro do dia).
+
+### Disputa
+
+Quando o iFood abre uma disputa (`DISPUTE`, `ORDER_DISPUTE` ou `CONSUMER_DISPUTE`):
+
+- O pedido é marcado como **`Em Disputa`** no banco
+- O movimento, se já existir, **NÃO é cancelado** automaticamente — a disputa pode ser resolvida a favor da loja no próprio iFood, e nesse caso a venda continua válida
+- A loja precisa acompanhar a disputa pelo painel do iFood e tomar decisão lá; o Sol.NET só registra que ela existe
+
+---
+
+## ❗ Limitações conhecidas
+
+- A integração captura **eventos de pedido** (criado, cancelado, em disputa). Outros eventos do iFood (atualização de cardápio, alteração de preço, fechamento da loja) **não são tratados** por esta integração.
+- A integração foi homologada com o fluxo **Aceitar → Iniciar Preparação → Pronto p/ Retirada → Finalizar Separação**. Lojas que pulam etapas (ex.: Aceitar direto para Finalizar) continuam funcionando, mas o cliente final no app não enxerga a evolução real do pedido — alinhe com a operação para usar todos os passos quando possível.
+- A finalização financeira do movimento depende **inteiramente** da configuração do `Tipo de Movimento iFood`. Erros de configuração no tipo (ex.: forma de pagamento errada, série fiscal trocada) refletem como erros no movimento gerado, não na tela iFood — diagnóstico vai pelo cadastro de tipos, não pelo monitor.
+
+---
+
+## 💡 Exemplos Práticos
+
+### Exemplo 1 — Pedido típico do almoço
+
+> 12:15. O monitor de integração roda há horas em background. Chega um pedido novo no iFood. O processo `Pedidos IFood` captura na rodada seguinte. A empresa "Restaurante Centro" tem `Confirmação = Manual` configurado.
+
+1. O atendente abre o `Monitor de Pedidos iFood` (F1 → `151`). O pedido aparece amarelo no grid.
+2. Atendente seleciona o pedido. Painel de itens carrega 3 itens, todos vinculados (verdes).
+3. Clica em `Aceitar Pedido`. O Sol.NET confirma na API; o pedido passa para `Confirmado` (linha sai do amarelo).
+4. Cozinha começa o preparo. Atendente clica em `Iniciar Preparação`. Linha fica azul. No app do cliente: "Seu pedido está sendo preparado".
+5. 10 minutos depois, pedido pronto. Atendente clica em `Pronto p/ Retirada`. App do cliente: "Aguardando entregador".
+6. Entregador iFood pega o pedido. Atendente clica em `Finalizar Separação`. Confirma a janela. Movimento de venda é criado no Sol.NET com os 3 itens, no tipo configurado para iFood.
+
+### Exemplo 2 — Cliente sem CPF, com ruptura de item
+
+> Sábado à noite. Pedido novo chega com 1 hambúrguer, 1 batata frita grande, 1 refrigerante. O cliente não informou CPF no app. Acabou a batata frita grande no estoque.
+
+1. Atendente aceita o pedido, inicia a preparação.
+2. Seleciona a linha da batata frita grande no grid de itens. Clica em `Excluir Item (Ruptura)`. Confirma. O Sol.NET avisa o iFood — o cliente recebe a notificação que aquele item saiu do pedido, e o iFood reembolsa o valor.
+3. Atendente prepara hambúrguer e refrigerante. Clica em `Pronto p/ Retirada`, depois `Finalizar Separação`.
+4. Como o pedido veio sem CPF/CNPJ, o Sol.NET grava o movimento no nome de **"Consumidor iFood"** — uma pessoa genérica que serve para vendas sem identificação.
+
+### Exemplo 3 — Cliente cancela pelo app depois da venda finalizada
+
+> Pedido aceito, separado, finalizado. Movimento gerado e parcela de cartão criada no `Contas a Receber`. 5 minutos depois, o cliente cancela pelo app porque pediu errado.
+
+1. O iFood envia evento `CANCELLATION_REQUEST` para a empresa.
+2. Próximo ciclo do monitor de integração captura o evento.
+3. O pedido vai para status `Cancelado` no banco.
+4. Como o movimento já tinha sido gerado pela finalização da separação, o Sol.NET **automaticamente cancela** o movimento e a parcela de Contas a Receber.
+5. No grid do monitor, ao filtrar o dia, o pedido aparece com status `Cancelado`. Atendente confere que o movimento também foi cancelado e segue o atendimento.
+
+### Exemplo 4 — Produto novo, código não bate com o cadastro
+
+> Pedido chega com um item "Pizza Especial Mês de Maio". O atendente cadastrou esse produto novo na semana passada, mas esqueceu de sincronizar o código com o iFood. O item aparece **vermelho** (sem vínculo) no grid.
+
+1. Atendente seleciona o item vermelho.
+2. Clica em `Vincular Produto`.
+3. Na janela de busca, digita o `Código` do produto "Pizza Especial Mês de Maio" no Sol.NET (ex.: `9981`). O sistema localiza, mostra a descrição e grava o vínculo.
+4. A linha do item vai para verde.
+5. Atendente segue o fluxo normal (Aceitar → Iniciar Preparação → Finalizar).
+6. Depois, o `Código` desse produto no Sol.NET é ajustado na sincronização de cardápio do iFood, para que os próximos pedidos do mesmo item já cheguem com o vínculo automático.
+
+---
+
+## ❓ FAQ / Problemas Comuns
+
+### ❓ Recebi um pedido pelo app mas ele não aparece no Monitor de Pedidos. O que pode ser?
+
+Verifique nessa ordem:
+1. O `Sol.NET Monitor de Integração` está em execução? Sem ele, **nenhum pedido entra**.
+2. O filtro `Data:` no monitor está no dia certo?
+3. A empresa que recebeu o pedido tem `Merchant ID iFood` preenchido no `Cadastro de Empresas`?
+4. A licença SAC iFood está ativa para essa empresa? Confira na Hetosoft.
+5. Force uma rodada manual: clique direito na janela do monitor de integração → `eCommerce → Pedidos IFood`.
+
+### ❓ O botão Aceitar Pedido está apagado/cinza. Por quê?
+
+O `Aceitar Pedido` só fica disponível quando o pedido está em status **`Aguardando`**. Se ele já passou para `Confirmado` (porque a empresa está com `Confirmação = Automático` ou alguém já aceitou), o próximo passo é `Iniciar Preparação`, não `Aceitar`.
+
+### ❓ Não consigo finalizar a separação. A tela avisa que tem item sem vínculo.
+
+Algum item do pedido está com linha vermelha no grid de itens. O Sol.NET não permite gerar o movimento com itens não vinculados (não saberia que produto colocar no movimento). Você tem duas opções:
+- **Vincular** o item ao produto correto com o botão `Vincular Produto`
+- **Excluir** o item por ruptura com o botão `Excluir Item (Ruptura)` (o cliente é reembolsado pelo iFood)
+
+### ❓ O cliente cancelou no app. Preciso fazer algo manualmente?
+
+**Não.** O processo automático já trata: marca o pedido como `Cancelado`, e se a venda já tinha gerado movimento e parcela, cancela tudo. Você só precisa intervir se notar que o cancelamento não foi pego automaticamente — nesse caso confirme que o monitor de integração está rodando.
+
+### ❓ Em que momento o estoque é baixado?
+
+A baixa de estoque acontece quando o **movimento é finalizado** — não no momento do `Finalizar Separação` do monitor iFood, mas dependendo do `Tipo de Movimento` configurado. Se o tipo finaliza automaticamente, a baixa é simultânea. Se o tipo deixa em aberto, a baixa acontece quando o financeiro/atendente finaliza pela tela `Vendas` (código `202`).
+
+### ❓ Posso usar iFood em mais de uma empresa do Sol.NET ao mesmo tempo?
+
+Sim. Cada empresa tem seu próprio `Merchant ID iFood`, sua própria licença SAC iFood, seu próprio `Tipo de Movimento iFood` e seu próprio modo de `Confirmação`. O monitor de integração varre todas as empresas configuradas em cada rodada. No grid do `Monitor de Pedidos iFood`, a coluna `Empresa` identifica de qual empresa é cada pedido.
+
+### ❓ Configurei `Confirmação = Automático`. Mesmo assim o atendente precisa fazer algo?
+
+Sim. As etapas de **aceitar** e de **iniciar a preparação** são dispensadas — o pedido já entra no monitor em `Em Preparação` (linha azul) e o Sol.NET avisa o iFood automaticamente que o preparo começou. O atendente continua precisando: ajustar itens em caso de ruptura, sinalizar pronto para retirada e finalizar a separação para gerar o movimento. O `Automático` serve para evitar o "stuck" de pedidos esperando aprovação em horários de pico — não substitui a operação humana de balcão.
+
+### ❓ O pedido apareceu duas vezes no grid. É bug?
+
+Não. A captura tem proteção contra duplicação (chave única por `Empresa + ID do Pedido`). Se está vendo duas linhas, provavelmente são dois pedidos diferentes do mesmo cliente — confirme pelo `Código` (short code do iFood) na primeira coluna; ele é único por pedido.
+
+### ❓ Tem como reabrir um pedido cancelado?
+
+**Não.** Cancelamento (recusa pela loja ou pelo cliente) é definitivo do ponto de vista da integração. Para vender de novo é preciso fazer um novo pedido no iFood.
+
+### ❓ A venda saiu no nome de "Consumidor iFood". Como mudo para o nome real do cliente?
+
+Pedidos sem CPF/CNPJ são lançados em "Consumidor iFood" para permitir que a venda aconteça. Se o cliente depois informar o documento, você pode **alterar a pessoa do movimento** na tela `Vendas` (código `202`) — desde que o movimento ainda esteja em estado editável e a permissão de alteração esteja liberada.
+
+### ❓ Preciso fazer alguma configuração de Forma de Pagamento na aba iFood?
+
+A aba iFood **não exige** configuração de forma de pagamento. A forma de pagamento da venda iFood vem do **`Tipo de Movimento`** configurado para a empresa — toda regra financeira (forma, condição, plano de contas) está definida lá. Configure o tipo de movimento iFood com a forma de pagamento adequada (ex.: "iFood — Crédito on-line") e tudo se resolve automaticamente.
+
+---
+
+**Última atualização**: Maio de 2026  
+**Versão**: 1.0  
+**Público-alvo**: Usuários do Sol.NET e atendentes de balcão

--- a/Integracoes/iFood/faq.md
+++ b/Integracoes/iFood/faq.md
@@ -1,0 +1,189 @@
+# 📄 FAQ: Pedidos iFood - Sol.NET
+
+## 🎯 Visão Geral
+
+Perguntas que aparecem com mais frequência no atendimento da integração de pedidos iFood. Para o passo-a-passo de operação, veja o [Guia Rápido](guia_rapido.md); para a referência completa, veja a [Documentação](documentacao_pedidos_ifood.md).
+
+---
+
+## ⚙️ Configuração inicial
+
+### ❓ Quais cadastros preciso fazer antes de começar a receber pedidos?
+
+Quatro pré-requisitos:
+
+1. **Licença SAC iFood** ativa na Hetosoft para a empresa
+2. **Merchant ID iFood** preenchido na aba `iFood` do `Cadastro de Empresas` (código `1`) — esse ID vem do iFood
+3. **Tipo de Movimento** configurado no `Cadastro de Tipos de Movimento` para representar a venda iFood, e selecionado na aba `iFood` do `Cadastro de Empresas`
+4. **`Sol.NET Monitor de Integração`** em execução no servidor
+
+Sem qualquer um deles, **pedidos não chegam**.
+
+> ⚠️ **Acesso de suporte necessário:** alterações no `Cadastro de Empresas` e no `Cadastro de Tipos de Movimento` requerem permissão de acesso de suporte. Entre em contato com o suporte Hetosoft antes de realizar qualquer modificação nessas telas.
+
+### ❓ Qual a diferença entre Confirmação `Manual` e `Automático` na aba iFood?
+
+- **`Manual`** — o atendente precisa clicar em **`Aceitar Pedido`** no monitor para que o Sol.NET sinalize ao iFood que a loja aceita. O pedido chega em status `Aguardando` (linha amarela), depois passa por `Confirmado` (Aceitar) e `Em Preparação` (Iniciar Preparação).
+- **`Automático`** — assim que o Sol.NET captura o pedido pela API, ele **já confirma** no iFood automaticamente e marca o pedido como `Em Preparação` (linha azul) no monitor — pulando os botões Aceitar Pedido e Iniciar Preparação. O atendente entra direto na separação dos itens.
+
+Os outros passos (Pronto p/ Retirada, Finalizar Separação, ajustes de itens) **continuam manuais** nos dois modos.
+
+### ❓ Posso usar a integração iFood em várias empresas do mesmo Sol.NET?
+
+Sim. Cada empresa configura seu próprio `Merchant ID iFood`, sua própria licença, seu próprio `Tipo de Movimento iFood` e seu próprio modo de `Confirmação`. O `Sol.NET Monitor de Integração` varre todas as empresas configuradas em cada rodada. No grid do `Monitor de Pedidos iFood` (código `151`), a coluna `Empresa` identifica de qual empresa é cada pedido.
+
+### ❓ Preciso configurar uma forma de pagamento específica na aba iFood?
+
+Não. A forma de pagamento da venda iFood vem do **`Tipo de Movimento`** configurado para a empresa — toda regra financeira (forma, condição, plano de contas) está definida lá. Use um tipo de movimento específico para iFood, com a forma adequada (ex.: "iFood — Crédito on-line"), e tudo se resolve automaticamente.
+
+---
+
+## 📥 Captura de pedidos
+
+### ❓ Recebi um pedido pelo app, mas ele não aparece no Monitor de Pedidos. Por quê?
+
+Verifique nessa ordem:
+
+1. O `Sol.NET Monitor de Integração` está em execução? Sem ele, **nenhum pedido entra**.
+2. O filtro `Data:` no topo do monitor está no dia certo?
+3. A empresa que recebeu o pedido tem `Merchant ID iFood` preenchido?
+4. A licença SAC iFood está ativa para essa empresa? Confirme com a Hetosoft.
+5. **Force uma rodada manual**: no `Sol.NET Monitor de Integração`, clique direito na janela de log → `eCommerce → Pedidos IFood`.
+
+### ❓ Como faço para forçar uma captura imediata sem esperar o próximo ciclo?
+
+No `Sol.NET Monitor de Integração`, clique com o **botão direito** na área de log e escolha **`eCommerce → Pedidos IFood`**. O processo executa imediatamente para todas as empresas configuradas. Volte ao `Monitor de Pedidos iFood` no Sol.NET e clique em **`Atualizar`** para ver os novos pedidos.
+
+### ❓ Se o Monitor de Integração ficar fora do ar, perco pedidos?
+
+**Não.** Os pedidos continuam entrando no iFood normalmente; só não chegam ao Sol.NET enquanto o monitor de integração estiver parado. Quando o monitor voltar a rodar, ele puxa o acúmulo da API de uma vez. Se a pausa for longa (mais de algumas horas), pode haver atraso no aceite — converse com o cliente sobre alarme de monitoração do serviço.
+
+### ❓ O pedido apareceu duas vezes no grid. É bug?
+
+Não. A captura tem proteção contra duplicação por chave única (`Empresa + ID do Pedido`). Se você vê duas linhas, são dois pedidos diferentes do mesmo cliente. Confirme pelo `Código` (short code do iFood) na primeira coluna — ele é único por pedido.
+
+---
+
+## 🔁 Operação no monitor
+
+### ❓ O botão `Aceitar Pedido` está apagado/cinza. Por quê?
+
+`Aceitar Pedido` só fica disponível para pedidos em status **`Aguardando`** (linha amarela). Se o pedido já passou para `Confirmado` (porque a empresa está com `Confirmação = Automático` ou outro atendente já aceitou), o próximo passo é `Iniciar Preparação`.
+
+### ❓ Não consigo finalizar a separação — a tela avisa que tem item sem vínculo.
+
+Algum item está com linha **vermelha** no grid de itens. O Sol.NET não permite gerar o movimento com itens não vinculados (não saberia que produto colocar no movimento).
+
+Resolva uma das duas formas:
+
+- 🔗 **Vincular** o item com `Vincular Produto`, informando o `Código` ou `ID` do produto certo
+- ❌ **Excluir** o item com `Excluir Item (Ruptura)` — o cliente é reembolsado pelo iFood
+
+### ❓ Quando posso ajustar quantidade ou excluir um item?
+
+Somente quando o pedido está em **`Em Preparação`** (linha azul). Antes disso (`Aguardando`, `Confirmado`) e depois (`Pronto p/ Retirada`, `Finalizado`) os botões de ajuste ficam desabilitados.
+
+Por isso o passo `Iniciar Preparação` é importante: ele "destrava" os botões de manipulação de itens.
+
+### ❓ Posso pular o `Pronto p/ Retirada` e ir direto para `Finalizar Separação`?
+
+Sim. O Sol.NET aceita finalizar a partir de `Em Preparação`. Mas o cliente final no app **não vai ver** o status "Aguardando entregador" — o pedido vai sumir das atualizações dele direto. Use `Pronto p/ Retirada` sempre que possível, é uma melhor experiência para o cliente.
+
+### ❓ Recusei o pedido errado. Como reverto?
+
+**Não há como reverter pela tela.** A recusa é enviada à API do iFood imediatamente, e o cliente é notificado. Se foi engano, entre em contato com o cliente por outro canal (telefone, observação do pedido se houver) — o pedido não volta para o monitor. Para vender o item, o cliente precisa fazer um novo pedido no app.
+
+---
+
+## 👤 Cliente e movimento
+
+### ❓ A venda saiu no nome de "Consumidor iFood". Como mudo para o nome real do cliente?
+
+Pedidos sem CPF/CNPJ no app são lançados em **"Consumidor iFood"** para permitir que a venda aconteça. Se o cliente depois informar o documento, você pode alterar a pessoa do movimento na tela `Vendas` (código `202`) — desde que o movimento ainda esteja em estado editável e a permissão de alteração esteja liberada.
+
+### ❓ O CPF vem do iFood, mas o cliente nunca tinha comprado aqui. O Sol.NET cria a pessoa?
+
+Sim. Quando o pedido traz CPF (11 dígitos) ou CNPJ (14 dígitos) e não existe pessoa cadastrada com aquele documento, o Sol.NET cria automaticamente uma **pessoa mínima** com o nome e o documento que vieram do app. Demais campos (endereço, telefone, e-mail) ficam vazios e podem ser preenchidos depois no `Cadastro de Pessoas` (código `5`).
+
+### ❓ Em que momento o estoque é baixado?
+
+Depende do `Tipo de Movimento` configurado para iFood:
+
+- Se o tipo **finaliza automaticamente** o movimento (emite documento fiscal, gera parcela financeira, baixa estoque), tudo isso acontece já no momento do `Finalizar Separação` no monitor.
+- Se o tipo deixa o movimento **em aberto** para conferência manual, a baixa de estoque só acontece quando o financeiro/atendente finalizar pela tela `Vendas` (código `202`).
+
+A integração não impõe um modo nem outro — ela respeita o tipo de movimento. Alinhe com o cliente qual o comportamento esperado e configure o tipo de acordo.
+
+### ❓ O movimento gerado fica em aberto. É normal?
+
+Sim — o `Finalizar Separação` do monitor iFood **cria o movimento em aberto**. A regra de finalização (emissão de NFC-e, conta a receber, baixa de estoque) é toda definida pelo `Tipo de Movimento iFood` configurado na empresa. Confira a configuração do tipo: se ele está marcado para finalizar/emitir automaticamente, isso já acontece junto da criação; senão, a finalização precisa ser manual em `Vendas`.
+
+---
+
+## 🚫 Cancelamentos e disputas
+
+### ❓ O cliente cancelou no app. Preciso fazer algo manualmente?
+
+**Não.** O processo automático trata sozinho:
+
+1. O monitor de integração captura o evento de cancelamento na próxima rodada
+2. Marca o pedido como `Cancelado` no banco
+3. Se o movimento já existia, cancela o movimento e a parcela em Contas a Receber
+
+Você só precisa intervir se notar que o cancelamento não foi pego. Nesse caso confirme que o monitor de integração está rodando.
+
+### ❓ O iFood abriu uma disputa. O que acontece com a venda no Sol.NET?
+
+O pedido é marcado como **`Em Disputa`** no banco, mas o movimento **NÃO é cancelado** automaticamente — a disputa pode ser resolvida a favor da loja no próprio iFood, e nesse caso a venda continua válida. Acompanhe a disputa pelo painel do iFood. Se a disputa for resolvida contra a loja, faça o cancelamento manual do movimento por dentro do Sol.NET.
+
+### ❓ Tem como reabrir um pedido cancelado?
+
+**Não.** Cancelamento (pela loja ou pelo cliente) é definitivo do ponto de vista da integração. Para vender de novo, o cliente precisa fazer um novo pedido no iFood.
+
+---
+
+## 🐞 Erros e bloqueios
+
+### ❓ Cliquei em `Aceitar Pedido` e o sistema avisou "Não foi possível confirmar o pedido na API do iFood". O que faz?
+
+A API do iFood rejeitou a confirmação. Causas comuns:
+
+- **Pedido já foi cancelado pelo cliente** entre a captura e o seu clique. Atualize o grid (`Atualizar`) e veja o novo status.
+- **Credencial expirada** — a integração faz refresh automático do token, mas se o iFood tiver feito alguma alteração recente, pode ser necessário re-autenticar a conta da loja no iFood antes que a confirmação volte a funcionar.
+- **Pedido com restrição na conta iFood** (cardápio fechado, loja pausada). Confira o painel do iFood.
+
+### ❓ Aceitei o pedido, separei, e na hora de finalizar deu erro "Falha ao criar movimento". E agora?
+
+O Sol.NET tentou criar o movimento mas algo bloqueou — provavelmente uma regra do `Tipo de Movimento iFood` (campo obrigatório não preenchido, configuração fiscal incompleta, falta de parâmetro). Recomendações:
+
+1. Anote o `Código` do pedido e a mensagem de erro exibida
+2. Revise a configuração do `Tipo de Movimento iFood` no `Cadastro de Tipos de Movimento` — corrija o que estiver faltando (forma de pagamento padrão, série fiscal, parâmetros fiscais)
+3. O pedido continua no monitor com status `Em Preparação` (ou `Pronto p/ Retirada`) — quando o tipo for corrigido, basta tentar `Finalizar Separação` de novo
+
+Não há **perda de dados** — o pedido fica em separação até alguém conseguir finalizar.
+
+### ❓ Vejo o pedido amarelo, mas ele tem status diferente quando seleciono. Por quê?
+
+A cor da linha é atualizada a cada `Atualizar`/recarga do grid. Se o pedido mudou de status entre a última atualização e agora (por exemplo, o cliente cancelou no app e o monitor de integração já capturou o cancelamento), clique em **`Atualizar`** para o grid refletir o status atual.
+
+---
+
+## 🧭 Acompanhamento e auditoria
+
+### ❓ Como vejo os pedidos cancelados/finalizados do dia inteiro para conferência fim de turno?
+
+Mantenha o `Monitor de Pedidos iFood` aberto com o filtro `Data:` no dia desejado. O grid mostra **todos os pedidos do dia**, em qualquer status, e a coluna `Status` (junto com a cor da linha) indica em que estado cada um está.
+
+### ❓ Como acho um pedido de dias anteriores?
+
+Mude o campo `Data:` no topo da tela para o dia que quer consultar. O grid recarrega automaticamente filtrando por aquela data.
+
+### ❓ Vou auditar a venda iFood do mês. Onde encontro os movimentos gerados pela integração?
+
+Os movimentos vão para a tela `Vendas` (código `202`) como qualquer outra venda — mas no `Tipo de Movimento` que você configurou para iFood. **Filtre por esse tipo** na consulta de movimentos para isolar só as vendas iFood do período.
+
+---
+
+**Última atualização**: Maio de 2026  
+**Versão**: 1.0  
+**Público-alvo**: Usuários do Sol.NET e atendentes de balcão

--- a/Integracoes/iFood/guia_rapido.md
+++ b/Integracoes/iFood/guia_rapido.md
@@ -1,0 +1,130 @@
+# 📄 Guia Rápido: Pedidos iFood - Sol.NET
+
+## 🎯 Visão Geral
+
+Cartão de operação do atendente no `Monitor de Pedidos iFood` (código `151`). Tenha à mão durante o turno.
+
+> **F1 → `151` → Enter** abre o monitor.
+
+---
+
+## ⚡ Antes de começar o turno
+
+- [ ] `Sol.NET Monitor de Integração` está em execução no servidor
+- [ ] Empresa está com `Merchant ID iFood` preenchido no `Cadastro de Empresas` (código `1`)
+- [ ] Tipo de Movimento iFood está configurado na aba `iFood` do `Cadastro de Empresas`
+
+> ⚠️ **Acesso de suporte necessário:** alterações no `Cadastro de Empresas` requerem permissão de acesso de suporte. Entre em contato com o suporte Hetosoft antes de realizar qualquer modificação nesta tela.
+
+Se algum item acima falhar, **pedidos não chegam**.
+
+---
+
+## 🎨 Significado das cores
+
+### No grid de pedidos
+
+| Cor da linha | Status | O que fazer |
+|--------------|--------|-------------|
+| 🟡 **Amarelo** | `Aguardando` | Aceitar ou Recusar |
+| 🔵 **Azul** | `Em Preparação` | Separar; ajustar itens se necessário |
+| ⚪ **Branco** | Outros (Confirmado, Pronto, Cancelado) | Conforme o status do painel de detalhe |
+
+### No grid de itens
+
+| Cor da linha | O que significa |
+|--------------|-----------------|
+| 🔴 **Vermelho** | Item **sem vínculo** com produto — precisa vincular OU excluir antes de finalizar |
+| ⚪ **Cinza tachado** | Item **excluído por ruptura** — vai ser ignorado na finalização |
+
+---
+
+## 🔁 Fluxo do pedido (passo-a-passo)
+
+### 1. 🟡 Pedido `Aguardando` (linha amarela)
+
+- Seleciona o pedido no grid
+- Confere itens (todos verdes/vinculados?), nome, observação
+- ✅ **`Aceitar Pedido`** (verde) → sinaliza para o iFood que aceitou
+- ❌ **`Recusar Pedido`** (vermelho) → abre tela de motivo (combo obrigatório + descrição opcional)
+
+> Empresa com `Confirmação = Automático`? O pedido **já chega em `Em Preparação`** (linha azul) — pule os passos 1 e 2 e vá direto para o passo 3 (ajustes de itens) ou 4 (Pronto p/ Retirada / Finalizar).
+
+### 2. ⚪ Pedido `Confirmado`
+
+- ✅ **`Iniciar Preparação`** (âmbar) → avisa o iFood; pedido vira azul
+- A partir daqui ficam habilitados os botões de ajustar itens
+
+### 3. 🔵 Pedido `Em Preparação` (linha azul)
+
+**Durante a separação**, se precisar:
+
+- 🔗 **`Vincular Produto`** — para itens vermelhos, informa código/ID do produto no Sol.NET
+- ⚖️ **`Ajustar Quantidade`** — informa a nova quantidade (>0). Sincroniza com o iFood.
+- ❌ **`Excluir Item (Ruptura)`** — item some do pedido. Sincroniza com o iFood (cliente é reembolsado pelo item).
+
+**Quando o pedido estiver pronto:**
+
+- ✅ **`Pronto p/ Retirada`** (azul) → avisa o iFood. Cliente vê "Aguardando entregador" no app.
+
+### 4. ✅ Pedido `Pronto p/ Retirada` (ou ainda `Em Preparação`)
+
+- ✅ **`Finalizar Separação`** (azul) → cria o movimento de venda no Sol.NET
+
+> ⚠️ Não permite finalizar se houver **item vermelho** (sem vínculo). Resolva o vínculo ou exclua o item.
+
+---
+
+## 🚫 Recusar pedido — passo a passo
+
+1. Selecione o pedido amarelo
+2. Clique em **`Recusar Pedido`**
+3. Na tela `Recusar Pedido iFood`:
+   - Escolha um motivo no combo **`Motivo *`** (obrigatório, lista vem da API do iFood)
+   - Se quiser, preencha **`Descrição adicional`** (opcional)
+   - Clique em **`Ok`**
+4. O Sol.NET chama a API; em sucesso, o pedido vira `Cancelado`
+
+> Se a API rejeitar (ex.: pedido já foi cancelado pelo cliente), o sistema avisa e nada é gravado. Atualize o grid e veja o novo status.
+
+---
+
+## 🔄 Forçar uma rodada de captura manual
+
+Quando você fez um pedido teste e quer ver chegar agora:
+
+1. Vá ao **`Sol.NET Monitor de Integração`** (a janela que fica rodando no servidor)
+2. Clique com **botão direito** na área de log
+3. Escolha **`eCommerce → Pedidos IFood`**
+4. Volte ao `Monitor de Pedidos iFood` no Sol.NET e atualize com o botão **`Atualizar`**
+
+---
+
+## 📅 Filtrar por data
+
+O `Monitor de Pedidos iFood` carrega o **dia atual** automaticamente. Para ver outros dias:
+
+- Mude o campo **`Data:`** no topo da tela — o grid recarrega sozinho.
+
+Útil para conferência fim de turno, auditoria fiscal ou revisão de cancelados.
+
+---
+
+## 🆘 Travou? Caminho rápido
+
+| Sintoma | Caminho rápido |
+|---------|----------------|
+| Pedido não aparece | Monitor de integração está rodando? Filtro de data está hoje? |
+| Botão Aceitar apagado | Pedido já está `Confirmado`. Próximo passo é `Iniciar Preparação`. |
+| Item vermelho | `Vincular Produto` ou `Excluir Item (Ruptura)` |
+| Bloqueou no finalizar | Tem item vermelho. Resolva todos antes. |
+| Cliente cancelou no app | Não precisa fazer nada. Próxima rodada do monitor cancela movimento+parcela automaticamente. |
+| Pedido em disputa | Acompanhar pelo painel do iFood; Sol.NET só registra. |
+
+Para casos não cobertos aqui, veja o [FAQ](faq.md) ou a [Documentação completa](documentacao_pedidos_ifood.md).
+
+---
+
+**Última atualização**: Maio de 2026  
+**Versão**: 1.0  
+**Público-alvo**: Atendentes de balcão e usuários do Sol.NET

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ mindmap
     🛒 Self Checkout
       Instalação
       Toledo Prix R7
+    🔌 Integrações
+      iFood — Pedidos
 ```
 
 Cada módulo segue o mesmo ritmo de três documentos: a **Documentação** (referência completa), o **Guia Rápido** (cheat-sheet do dia a dia) e o **FAQ** (perguntas que aparecem todo dia no suporte). Comece pela Documentação quando estiver aprendendo, mantenha o Guia Rápido por perto quando estiver operando.
@@ -59,4 +61,4 @@ Cada módulo segue o mesmo ritmo de três documentos: a **Documentação** (refe
 
 ---
 
-<p align="center"><sub>📅 Última atualização: Maio de 2026 · 📦 Versão 3.0 · 👥 Hetosoft — Sol.NET ERP</sub></p>
+<p align="center"><sub>📅 Última atualização: Maio de 2026 · 📦 Versão 3.1 · 👥 Hetosoft — Sol.NET ERP</sub></p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -596,6 +596,24 @@
             </ul>
           </details>
 
+          <details class="sn-sidebar__group" data-sn-group="integracoes">
+            <summary class="sn-sidebar__group-summary">🔌 Integrações</summary>
+            <ul class="sn-sidebar__items">
+              <li><a href="{{ '/Integracoes/' | relative_url }}">Visão geral</a></li>
+              <li class="sn-sidebar__subgroup-item">
+                <details class="sn-sidebar__subgroup" data-sn-subgroup="ifood">
+                  <summary class="sn-sidebar__subgroup-summary">🍔 iFood — Pedidos</summary>
+                  <ul class="sn-sidebar__subitems">
+                    <li><a href="{{ '/Integracoes/iFood/' | relative_url }}">Visão geral</a></li>
+                    <li><a href="{{ '/Integracoes/iFood/documentacao_pedidos_ifood/' | relative_url }}">Documentação</a></li>
+                    <li><a href="{{ '/Integracoes/iFood/guia_rapido/' | relative_url }}">Guia Rápido</a></li>
+                    <li><a href="{{ '/Integracoes/iFood/faq/' | relative_url }}">FAQ</a></li>
+                  </ul>
+                </details>
+              </li>
+            </ul>
+          </details>
+
         </nav>
 
         <div class="sn-sidebar__footer">


### PR DESCRIPTION
## Resumo

Cria a documentação completa da **Integração de Pedidos iFood** liberada pelo PR [hetosoft/ProjetosSol.NET#8412](https://github.com/hetosoft/ProjetosSol.NET/pull/8412) (branch `feature/ifood-pedidos-integracao`).

A integração introduz um novo módulo no portal: **`Integracoes/`** — guarda-chuva para integrações com plataformas externas. O primeiro tema é **iFood**, com a subpasta `Integracoes/iFood/`.

## O que foi criado

| Arquivo | Papel |
|---------|-------|
| `Integracoes/README.md` | Índice do módulo guarda-chuva |
| `Integracoes/iFood/README.md` | Sub-índice do tema iFood |
| `Integracoes/iFood/documentacao_pedidos_ifood.md` | Referência completa |
| `Integracoes/iFood/guia_rapido.md` | Cartão de operação do atendente |
| `Integracoes/iFood/faq.md` | Perguntas comuns do atendimento |

## Conteúdo coberto

- **Pré-requisitos**: licença SAC iFood, Merchant ID, sincronização de produtos, Tipo de Movimento, Monitor de Integração rodando.
- **Configuração** na aba `iFood` do `Cadastro de Empresas` (código `1`): Tipo de Movimento e modo de Confirmação (`Manual` × `Automático`).
- **Captura automática** pelo `Sol.NET Monitor de Integração` (processo `Pedidos IFood`), incluindo execução manual via menu de contexto.
- **Fluxo no `Monitor de Pedidos iFood`** (código `151`): Aceitar / Recusar (com motivo da API), Iniciar Preparação, Pronto p/ Retirada, Finalizar Separação.
- **Ajustes durante a separação**: ajustar quantidade, excluir item por ruptura (com sincronização para o iFood), vincular produto manualmente.
- **Resolução de cliente**: pessoa criada por CPF/CNPJ ou \"Consumidor iFood\" quando o pedido vem sem documento.
- **Cancelamentos e disputas** vindos do iFood, com cancelamento automático do movimento e das parcelas a receber quando o movimento já foi gerado.
- **Movimento gerado**: criado em aberto; toda regra contábil/fiscal/financeira fica a cargo do `Tipo de Movimento iFood` configurado.

## Códigos de tela citados

| Tela | Código (`ID_FORMULARIO`) |
|------|----|
| `Cadastro de Empresas` | `1` |
| `Cadastro de Pessoas` | `5` |
| `Cadastro de Produtos` | `32` |
| `Vendas` | `202` |
| `Monitor de Pedidos iFood` | `151` (novo) |

Códigos validados em `Sol.NET/Dal/ProcessosAtualizacao/uProcessosAtualizacaoPrincipal.pas` na branch `feature/ifood-pedidos-integracao`.

## Atualizações de infraestrutura

- **Sidebar** (`_layouts/default.html`): novo grupo `🔌 Integrações` com subgrupo aninhado `🍔 iFood — Pedidos`.
- **Portal `README.md`**: mindmap inclui o novo módulo; rodapé sobe **Versão 3.0 → 3.1** (módulo novo justifica bump).
- A nota canônica `⚠️ Acesso de suporte necessário` aparece em todas as menções a alteração no `Cadastro de Empresas` e no `Cadastro de Tipos de Movimento` (regra da skill `solnet-docs`).

## Decisões alinhadas com o usuário

- **Módulo**: `Integracoes/iFood/` (subpasta), abrindo espaço para futuras integrações.
- **Forma de Pagamento** na aba iFood: **não documentada** (vai ser removida na próxima revisão da tela).
- **Confirmação Automática**: confirmado pelo usuário e validado no código (`Integracao.IFood.Pedidos.pas`) — o pedido é gravado direto em `Em Preparação` e a API é confirmada automaticamente, pulando dois botões do fluxo (Aceitar e Iniciar Preparação).
- **Finalização financeira do movimento**: documentada como dependente do Tipo de Movimento configurado.
- **\"Consumidor iFood\"** documentado literalmente para pedidos sem CPF/CNPJ.
- Documentação do submenu \"Pedidos IFood\" no `Sol.NET Monitor de Integração` incluída (execução imediata da rodada).

## Test plan

- [ ] Verificar renderização do site após merge: <https://hetosoft.github.io/documentacao-solnet/Integracoes/>
- [ ] Confirmar que o novo grupo \"Integrações\" aparece na sidebar com o subgrupo \"iFood — Pedidos\" aninhado
- [ ] Validar o diagrama Mermaid (`stateDiagram-v2`) do fluxo de status
- [ ] Conferir links cruzados entre os três docs filhos (README, documentação, guia rápido, FAQ)
- [ ] Verificar mindmap atualizado e novo rodapé Versão 3.1 no portal raiz