### PR TITLE
docs: cria documentação da Região ICMS ST Saída no módulo Fiscal

### DIFF
--- a/Fiscal/README.md
+++ b/Fiscal/README.md
@@ -110,7 +110,18 @@ Checklists separados para Naturezas de Saída e de Entrada, anatomia das abas (I
 #### ❓ [Natureza de Operação — FAQ](faq_natureza_operacao.md)
 Conceito, autocomplete do CFOP, regras fiscais, flags Manter, Importar XML, Reforma Tributária e como a Natureza chega ao item do movimento.
 
-> 🚧 **Em fila**: Região ICMS ST Saída (`94`) fecha este subgrupo.
+#### 📖 [Região ICMS ST Saída — Documentação](documentacao_regiao_icms_st_saida.md)
+Tela `94`: regras de cálculo do ICMS por Substituição Tributária. Trabalha com:
+- Percentuais diretos de **B.C. ICMS ST**, **MVA** e **alíquota ICMS-ST** por contexto
+- Vínculo por **Produto** ou por **Pessoa**, com bloqueio de exclusão quando há produtos vinculados
+- Flag `Usar MVA NCM` para puxar a margem direto do NCM do item
+- Modo de cálculo `Industria MT` para o regime de indústrias de Mato Grosso
+
+#### ⚡ [Região ICMS ST Saída — Guia Rápido](guia_rapido_regiao_icms_st_saida.md)
+Checklist para cadastrar uma Região ICMS-ST, anatomia da tela, formato das listas de lojas/estados, operações do detalhe e erros mais comuns.
+
+#### ❓ [Região ICMS ST Saída — FAQ](faq_regiao_icms_st_saida.md)
+Diferença para a `93`, escolha entre Tipo `PRODUTO` × `PESSOA`, papel do `Usar MVA NCM`, quando usar `Industria MT` e como destravar a exclusão quando há produtos vinculados.
 
 ---
 
@@ -130,5 +141,5 @@ Conceito, autocomplete do CFOP, regras fiscais, flags Manter, Importar XML, Refo
 ---
 
 **📅 Última atualização**: Maio de 2026  
-**📦 Versão**: 1.6  
+**📦 Versão**: 1.7  
 **🎯 Público-alvo**: Usuários, contadores, configuradores e equipe de suporte Sol.NET

--- a/Fiscal/documentacao_regiao_icms_st_saida.md
+++ b/Fiscal/documentacao_regiao_icms_st_saida.md
@@ -1,0 +1,192 @@
+# 📄 Cadastro de Região ICMS ST Saída — Sol.NET
+
+## 🎯 Visão Geral
+
+O **Cadastro de Região ICMS ST Saída** (`94`) define as regras que o Sol.NET usa para calcular o **ICMS por Substituição Tributária (ICMS-ST)** em cada item da operação. A tela funciona como um conjunto de **filtros + percentuais**: quando o contexto da operação combina com uma linha (loja emissora, UF do destinatário, perfil do destinatário, etc.), o sistema aplica a `Base de cálculo ST`, a `MVA` (Margem de Valor Agregado) e a `Alíquota ICMS-ST` definidas naquela linha.
+
+Diferente do Cadastro de Região ICMS Saída (`93`), que mapeia contexto → Natureza de Operação, a `Região ICMS ST` **armazena diretamente os percentuais** que entram na conta do ICMS-ST.
+
+### Principais características
+
+- ✅ Define **Base ST, MVA e Alíquota ICMS-ST** para cada cenário fiscal
+- ✅ Permite múltiplas **linhas de detalhe** filtradas por loja, UF, CNAE, indicador de IE, atividade comercial e regime tributário do destinatário
+- ✅ Modo `Usar MVA NCM` — ignora a MVA da linha e usa a registrada no NCM do item
+- ✅ Funciona em dois modos de associação: por **Produto** (vinculada ao item) ou por **Pessoa** (vinculada ao destinatário)
+- ✅ Bloqueia a exclusão se houver produtos vinculados a ela (somente para Tipo `PRODUTO`)
+
+---
+
+## 🚪 Como acessar
+
+Abra a pesquisa universal (`F1`), digite `Região ICMS ST Saída` ou o código `94`, e abra a tela.
+
+---
+
+## 🧩 O que define uma Região ICMS-ST
+
+O cabeçalho identifica a regra como um todo e decide **como ela será vinculada** aos movimentos.
+
+| Campo | O que define |
+|---|---|
+| **Tipo** | Como a Região é encontrada durante a emissão: `PRODUTO` (vinculada ao cadastro do produto) ou `PESSOA` (vinculada ao cadastro do destinatário). |
+| **Descrição** | Texto livre, obrigatório, até 80 caracteres. **Pode repetir** entre regiões de Tipos diferentes — ex.: pode existir uma `INDÚSTRIA SP` do tipo `PRODUTO` e outra `INDÚSTRIA SP` do tipo `PESSOA`. |
+
+### Como cada Tipo é aplicado no movimento
+
+- **`PRODUTO`** — a Região é apontada pelo cadastro do produto. Durante o movimento, o sistema lê a Região vinculada ao item, escolhe a linha cujos filtros casam com o contexto da operação e aplica os percentuais.
+- **`PESSOA`** — a Região é apontada pelo cadastro da pessoa (cliente). O sistema usa a Região do destinatário do movimento, independentemente do produto.
+
+> 💡 As duas formas convivem. O cliente pode preferir uma ou outra dependendo de como o cálculo do ICMS-ST varia mais — pela natureza do item ou pelo perfil de quem compra.
+
+---
+
+## 📋 Linhas de configuração
+
+A área `Configurações` é um **sub-cadastro** com seus próprios botões `Inserir`, `Atualizar`, `Deletar` e `Cancelar`. Cada linha define um conjunto de filtros e os percentuais que serão usados quando aquele conjunto for atendido.
+
+### Filtros — quando a linha se aplica
+
+Os filtros são **curingas**: deixar vazio ou em `-1` significa "qualquer valor". O sistema escolhe a linha mais específica que combina com o contexto.
+
+| Campo | O que filtra |
+|---|---|
+| **Nº Lojas** | Códigos de filial emissora separados por `/`, ex.: `/1/2/`. Vazio = todas as lojas. O sistema adiciona as barras automaticamente ao sair do campo. |
+| **Sigla Estados** | UFs do destinatário separadas por `/`, ex.: `/BA/SP/`. Vazio = todas. As barras são acrescentadas automaticamente. |
+| **CNAE - Fiscal** | CNAE do destinatário. Duplo clique ou tecla de busca abre a tela `Cadastro de CNAE`. O botão de lixeira (esquerdo) limpa o campo. |
+| **Indicador IE** | Indicador de Inscrição Estadual do destinatário, conforme padrão SEFAZ: `1 — Contribuinte`, `2 — Isento`, `9 — Não Contribuinte`. Vazio/`-1` = qualquer. |
+| **Atividade Comercial** | `Consumidor`, `Revenda` ou `Indústria`. Vazio/`-1` = qualquer. |
+| **Regime Tributário** | Regime do destinatário: `Simples Nacional`, `Lucro Real` ou `Lucro Presumido`. Vazio/`-1` = qualquer. |
+| **Cálculo** | Modo de cálculo do ICMS-ST. Veja `🧮 Modos de cálculo` abaixo. |
+| **Tipo** (radio) | `Saída` ou `Entrada`. Define se a linha vale para operações que saem do estoque ou que entram. |
+| **Selecione** (radio) | Onde a operação acontece: `Dentro do Estado`, `Fora do Estado` ou `Exterior`. |
+
+### Percentuais — o que a linha aplica
+
+| Campo | O que faz |
+|---|---|
+| **B.C. ICMS ST** | Percentual de **redução da base de cálculo** do ICMS-ST. Ex.: `100,00%` = sem redução; `60,00%` = aplicar sobre 60% da base. |
+| **MVA** | Margem de Valor Agregado (%) usada para compor a base de cálculo do ICMS-ST. No modo de cálculo `Industria MT`, este mesmo campo é usado como **Margem de Lucro**. |
+| **ICMS ST Aliq.** | Alíquota do ICMS-ST (%). No modo de cálculo `Industria MT`, este mesmo campo armazena a **Carga Média**. |
+| **Usar MVA NCM** | Quando marcado, o sistema **ignora a MVA digitada na linha** e usa a MVA cadastrada no NCM do item. Útil quando a MVA varia produto a produto e já está mantida no NCM. |
+
+---
+
+## 🧮 Modos de cálculo
+
+O combo `Cálculo` define como os percentuais da linha entram na conta do ICMS-ST.
+
+| Modo | Quando usar |
+|---|---|
+| **Normal** | Cálculo padrão de ICMS-ST: base × MVA → aplicar redução de base (`B.C. ICMS ST`) → aplicar `ICMS ST Aliq.`. É o modo da maioria dos cenários. |
+| **Industria MT** | Cálculo específico para clientes do tipo **indústria estabelecida em Mato Grosso**. Nesse modo, o campo `MVA` representa a **Margem de Lucro** e o campo `ICMS ST Aliq.` representa a **Carga Média**. A regra exata do cálculo varia conforme o regime estadual e deve ser confirmada com a contabilidade do cliente. |
+
+---
+
+## 🚫 Regras e restrições
+
+### Exclusão bloqueada quando há produtos vinculados
+
+Se o Tipo da Região é `PRODUTO` e houver pelo menos um produto apontando para ela, a tela impede a exclusão e exibe:
+
+> *Não permitido, Existe Produto(s) com essa Região!*
+
+Para excluir, é preciso primeiro desvincular ou trocar a Região nesses produtos. Para Tipo `PESSOA` não há essa checagem na exclusão — o usuário é responsável por manter o vínculo nas pessoas que apontavam para a Região excluída.
+
+### Descrição pode duplicar
+
+A tela **não valida unicidade da Descrição**. Duas regiões com o mesmo texto são permitidas, normalmente para combinar com a separação por Tipo (`PRODUTO` × `PESSOA`).
+
+### Normalização de listas
+
+Ao sair dos campos `Nº Lojas` e `Sigla Estados`, o Sol.NET insere automaticamente `/` no início e no final do conteúdo digitado. Ou seja, digitar `1,2` resulta em `/1,2/`, e digitar `BA/SP` resulta em `/BA/SP/`. Use **um item por par de barras** (`/1/2/`, `/BA/SP/`) para que o casamento de filtro funcione.
+
+### Edição de detalhe em andamento
+
+Se há uma linha de detalhe sendo inserida ou alterada (`Inserir` ou edição em curso) e o operador tenta sair da área `Configurações` sem confirmar, o sistema bloqueia a saída com a mensagem padrão de cadastro em edição e devolve o foco para o primeiro campo. Use **Atualizar** para gravar ou **Cancelar** para descartar antes de mudar de seção.
+
+---
+
+## 💡 Exemplos Práticos
+
+### Exemplo 1 — Venda para revenda em SP, alíquota fixa
+
+A loja `1` vende para revendedores no estado de SP, contribuintes de ICMS, regime Lucro Presumido. A MVA pactuada com o estado é 35%, sem redução de base, alíquota efetiva 18%.
+
+| Campo | Valor |
+|---|---|
+| Tipo | `PRODUTO` |
+| Descrição | `REVENDA SP — MVA 35%` |
+| **Linha de detalhe** | |
+| Nº Lojas | `/1/` |
+| Sigla Estados | `/SP/` |
+| Indicador IE | `Contribuinte` |
+| Atividade Comercial | `Revenda` |
+| Regime Tributário | `Lucro Presumido` |
+| Cálculo | `Normal` |
+| Tipo | `Saída` |
+| Selecione | `Fora do Estado` |
+| B.C. ICMS ST | `100,00%` |
+| MVA | `35,00%` |
+| ICMS ST Aliq. | `18,00%` |
+
+Depois de salvar, vincule esta Região nos cadastros dos produtos que devem usar essa regra.
+
+### Exemplo 2 — Mesmo cenário, mas com MVA variável por produto
+
+Se a MVA muda produto a produto (e já está mantida nos cadastros de NCM), repita a configuração acima e marque **`Usar MVA NCM`** na linha. O percentual `MVA` da linha vira informativo — quem manda no cálculo é a MVA do NCM do item.
+
+### Exemplo 3 — Regra pelo perfil do cliente (não pelo produto)
+
+Um cliente atacadista compra produtos diversos, mas a regra de ICMS-ST que se aplica a ele é sempre a mesma. Em vez de configurar produto a produto:
+
+1. Cadastre uma Região com Tipo `PESSOA` e descrição `ATACADO — REGRA ÚNICA`.
+2. Configure as linhas de detalhe normalmente.
+3. Aponte essa Região no cadastro do atacadista.
+
+Em qualquer movimento desse cliente, o Sol.NET usa essa Região, independentemente do produto.
+
+---
+
+## ❓ FAQ / Problemas Comuns
+
+### ❓ Posso ter duas Regiões com a mesma Descrição?
+
+Sim. A tela não bloqueia duplicidade de Descrição. O uso mais comum é ter uma `PRODUTO` e uma `PESSOA` com o mesmo nome para cobrir os dois modos de associação.
+
+### ❓ Qual a diferença para a tela Região ICMS Saída (`93`)?
+
+A `93` é um **mapa de Natureza de Operação** — ela diz qual Natureza usar em cada contexto, e os valores fiscais vêm da Natureza. A `94` armazena diretamente os **percentuais de ICMS-ST** (Base, MVA, Alíquota) e os aplica em quem combina com os filtros. As duas convivem: a `93` cuida do ICMS normal/CFOP/CST; a `94` cuida especificamente do ICMS-ST.
+
+### ❓ Marquei `Usar MVA NCM`, mas o sistema ainda usa a MVA da linha. Por quê?
+
+Confirme que o NCM do item realmente tem MVA cadastrada. Se o NCM estiver com MVA em branco, o cálculo pode cair de volta no valor da linha. Verifique também se o produto está apontando para o NCM correto.
+
+### ❓ Por que o combo `Cálculo` mostra um item em branco no final?
+
+É um item descontinuado que sobrou no cadastro. Use somente `Normal` ou `Industria MT`.
+
+### ❓ Quando devo usar `Industria MT`?
+
+Quando o cliente é uma **indústria estabelecida no estado de Mato Grosso**, sujeita ao regime estadual específico que troca MVA por Margem de Lucro e alíquota por Carga Média. A fórmula exata depende da legislação estadual vigente e deve ser confirmada com a contabilidade. Para os demais cenários, use `Normal`.
+
+### ❓ Tentei excluir uma Região e o sistema avisou "Existe Produto(s) com essa Região". O que fazer?
+
+A Região está vinculada a um ou mais produtos. Abra o cadastro de produtos, localize os que apontam para essa Região e troque pela Região correta (ou deixe em branco). Depois disso a exclusão será liberada.
+
+### ❓ Posso usar tanto Região `PRODUTO` quanto Região `PESSOA` no mesmo movimento?
+
+Não simultaneamente para o mesmo item. O sistema usa a Região vinculada ao cadastro que dá origem ao cálculo (produto ou pessoa). A escolha entre os dois modos é definida no momento do cadastro da Região e do vínculo.
+
+### ❓ Como faço para uma linha valer para qualquer estado?
+
+Deixe `Sigla Estados` em branco. O mesmo vale para `Nº Lojas` (qualquer loja), `Indicador IE`, `Atividade Comercial`, `Regime Tributário` e `CNAE` — vazio significa "qualquer valor".
+
+### ❓ Mudei os percentuais e o movimento já emitido continua com o valor antigo. É bug?
+
+Não. O Sol.NET calcula o ICMS-ST no momento da emissão usando os percentuais válidos naquele instante. Movimentos já gravados mantêm os valores históricos. Para reprocessar, o movimento precisa ser refeito.
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 1.0
+**Público-alvo**: Equipe de Suporte / Usuários do Sol.NET / Contabilidade

--- a/Fiscal/faq_regiao_icms_st_saida.md
+++ b/Fiscal/faq_regiao_icms_st_saida.md
@@ -1,0 +1,129 @@
+# ❓ FAQ — Região ICMS ST Saída
+
+Perguntas frequentes sobre o **Cadastro de Região ICMS ST Saída** (código `94`) do Sol.NET. Para a referência completa, abra a [Documentação da Região ICMS ST Saída](documentacao_regiao_icms_st_saida.md).
+
+---
+
+## 📋 Conceito e estrutura
+
+### ❓ O que a tela `Região ICMS ST Saída` faz exatamente?
+
+Armazena conjuntos de **percentuais de ICMS-ST** (`B.C. ICMS ST`, `MVA`, `ICMS ST Aliq.`) e os aplica em cada item da operação cujo contexto combina com os filtros de uma linha de detalhe (loja emissora, UF do destinatário, perfil do destinatário, CNAE, regime, etc.).
+
+### ❓ Qual a diferença para a tela `Região ICMS Saída` (`93`)?
+
+A `93` é um **mapa de Natureza de Operação** — diz qual Natureza usar em cada contexto, e os valores fiscais (CST, alíquota, CSOSN, CFOP, CBS, IBS) vêm da Natureza vinculada. A `94` **armazena diretamente os percentuais** de ICMS-ST e os aplica. As duas convivem: a `93` cuida do ICMS normal e da escolha de CFOP; a `94` cuida especificamente do cálculo do ICMS-ST.
+
+### ❓ Qual a diferença entre Tipo `PRODUTO` e Tipo `PESSOA`?
+
+- **`PRODUTO`** — a Região é apontada pelo **cadastro do produto**. Use quando a regra de ICMS-ST varia mais pela natureza do item do que pelo destinatário.
+- **`PESSOA`** — a Região é apontada pelo **cadastro da pessoa** (cliente). Use quando o cliente tem uma regra fixa que vale para qualquer produto que ele compra.
+
+Ambos os modos podem coexistir no mesmo Sol.NET — basta cadastrar uma Região para cada modo.
+
+### ❓ Por que o cadastro tem duas partes: cabeçalho e configurações?
+
+O **cabeçalho** identifica a regra como um todo (`Tipo`, `Descrição`). As **configurações** são as linhas de detalhe — cada uma cobre um contexto fiscal específico. Uma mesma Região pode ter várias linhas, e o Sol.NET escolhe a mais específica que casa com o contexto do movimento.
+
+### ❓ A tela vale só para Saída?
+
+Apesar do nome, o radio `Tipo` na linha de detalhe permite marcar `Entrada` também. Na prática, a tela cobre operações em que o sistema precisa calcular ICMS-ST — habitualmente saída, mas com suporte a entradas quando a configuração fiscal exige.
+
+---
+
+## 🧮 Percentuais e cálculo
+
+### ❓ Para que serve o campo `B.C. ICMS ST`?
+
+É o percentual da **base de cálculo do ICMS-ST após redução**. `100,00%` significa que a base completa é usada; `60,00%` significa que apenas 60% da base entra na conta.
+
+### ❓ Para que serve o campo `MVA`?
+
+Margem de Valor Agregado, em percentual. O Sol.NET aplica essa margem sobre o valor do item para compor a base do ICMS-ST. No modo de cálculo `Industria MT`, este mesmo campo é usado como **Margem de Lucro**.
+
+### ❓ Para que serve o campo `ICMS ST Aliq.`?
+
+Alíquota do ICMS-ST em percentual. No modo de cálculo `Industria MT`, este mesmo campo é usado como **Carga Média**.
+
+### ❓ Quando devo marcar `Usar MVA NCM`?
+
+Quando a MVA varia produto a produto e já está mantida no Cadastro de NCM. Com a flag marcada, o sistema **ignora a MVA digitada na linha** e busca a MVA do NCM do item. É útil para regras genéricas que cobrem muitos produtos sem precisar duplicar linhas só por causa da MVA.
+
+### ❓ Marquei `Usar MVA NCM`, mas o cálculo ainda usa a MVA da linha. Por quê?
+
+Verifique se o NCM do item realmente tem MVA cadastrada. Sem MVA no NCM, o cálculo pode cair de volta para a MVA da linha. Confirme também se o produto está apontando para o NCM correto.
+
+### ❓ Quando devo usar `Industria MT` no combo `Cálculo`?
+
+Quando o cliente é uma **indústria estabelecida em Mato Grosso** sujeita ao regime estadual específico que substitui MVA por Margem de Lucro e alíquota por Carga Média. A fórmula exata depende da legislação estadual e deve ser validada com a contabilidade. Em todos os outros cenários, use `Normal`.
+
+### ❓ O combo `Cálculo` mostra um item em branco no final. O que é?
+
+Item descontinuado que sobrou no cadastro. Use somente `Normal` ou `Industria MT`.
+
+---
+
+## 🧷 Filtros e curingas
+
+### ❓ Como faço uma linha valer para qualquer estado?
+
+Deixe `Sigla Estados` em branco. O mesmo vale para qualquer outro filtro: `Nº Lojas`, `CNAE`, `Indicador IE`, `Atividade Comercial`, `Regime Tributário`. Vazio (ou `-1` em combos) significa "qualquer valor".
+
+### ❓ Posso listar vários estados ou várias lojas numa mesma linha?
+
+Sim. Separe os valores por barra `/`, ex.: `/BA/SP/MG/` ou `/1/2/3/`. O Sol.NET acrescenta as barras inicial e final automaticamente ao sair do campo.
+
+### ❓ Qual a relação entre as opções `Indicador IE` (`1`, `2`, `9`) e a SEFAZ?
+
+Seguem o padrão da SEFAZ para Indicador de Inscrição Estadual do destinatário: `1 — Contribuinte`, `2 — Isento`, `9 — Não Contribuinte`. Esse mesmo código vai para a NF-e.
+
+### ❓ E se duas linhas atendem ao mesmo contexto?
+
+O Sol.NET prefere a linha mais específica. Quando há empate de especificidade, a regra é não-determinística e deve ser evitada — refine os filtros para que cada combinação aponte para uma única linha.
+
+---
+
+## ✏️ Cadastro e operação
+
+### ❓ Posso ter duas Regiões com a mesma Descrição?
+
+Sim. A tela não bloqueia duplicidade. O caso comum é uma Região `PRODUTO` e outra `PESSOA` com o mesmo nome para indicar que cobrem o mesmo cenário pelos dois modos de vínculo.
+
+### ❓ Por que ao tentar sair da área `Configurações` o sistema mostra "Existe cadastro em edição"?
+
+Porque há uma linha de detalhe em inserção ou edição que ainda não foi confirmada. Clique `Atualizar` para gravar a linha ou `Cancelar` para descartar antes de mudar de seção ou fechar a tela.
+
+### ❓ Tentei excluir uma Região e apareceu "Existe Produto(s) com essa Região". Como resolver?
+
+A Região (Tipo `PRODUTO`) está vinculada a um ou mais produtos. Abra o `Cadastro de Produtos`, localize quem aponta para essa Região e troque ou limpe o vínculo. Depois disso, a exclusão fica liberada. Para Tipo `PESSOA` não há esse bloqueio — a exclusão é livre, e cabe ao operador atualizar os cadastros de pessoas que ficaram apontando para uma Região inexistente.
+
+### ❓ Onde vinculo a Região cadastrada aos produtos ou pessoas?
+
+- Tipo `PRODUTO` → no `Cadastro de Produtos` (`32`), no campo que aponta para `Região ICMS ST`.
+- Tipo `PESSOA` → no `Cadastro de Pessoas` (`5`), no campo equivalente.
+
+### ❓ Mudei os percentuais e o movimento já emitido continua com o valor antigo. É bug?
+
+Não. O Sol.NET calcula o ICMS-ST **no momento da emissão**. Movimentos já gravados mantêm os valores históricos. Para reaplicar a nova regra, o movimento precisa ser refeito.
+
+---
+
+## 🔗 Relação com outras telas
+
+### ❓ Esta tela substitui o cadastro da Natureza de Operação?
+
+Não. As duas convivem: a Natureza de Operação (`36`) define CFOP, CST e tributos gerais; a Região ICMS-ST (`94`) define os percentuais específicos do ICMS-ST. O cálculo final combina as duas fontes.
+
+### ❓ Onde a tela busca o CNAE selecionado no filtro?
+
+A busca abre o `Cadastro de CNAE`. O campo armazena o código `SUBCLASSE` do CNAE selecionado e exibe esse mesmo código para o operador.
+
+### ❓ A configuração depende do Cadastro de Tipo de Movimento?
+
+Indiretamente: o `Cadastro de Tipo de Movimento` decide se uma operação calcula ICMS-ST e em que momento. Quando o cálculo é acionado, o Sol.NET vai buscar nesta tela qual linha aplicar.
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 1.0
+**Público-alvo**: Equipe de Suporte / Usuários do Sol.NET / Contabilidade

--- a/Fiscal/guia_rapido_regiao_icms_st_saida.md
+++ b/Fiscal/guia_rapido_regiao_icms_st_saida.md
@@ -1,0 +1,90 @@
+# ⚡ Guia Rápido — Região ICMS ST Saída
+
+## 🎯 Para que serve
+
+Cartão de referência para configurar e diagnosticar regras de ICMS-ST. Para a explicação completa, abra a [Documentação da Região ICMS ST Saída](documentacao_regiao_icms_st_saida.md).
+
+A tela `Região ICMS ST Saída` (`94`) armazena **percentuais de ICMS-ST** (Base, MVA, Alíquota) que o Sol.NET aplica em cada item conforme o contexto da operação combina com os filtros das linhas de detalhe.
+
+---
+
+## 🚪 Como abrir
+
+Pela pesquisa universal (`F1`), digite `Região ICMS ST Saída` ou o código `94`.
+
+---
+
+## 📋 Checklist — cadastrar uma Região ICMS-ST
+
+1. ☐ Definir o **Tipo**: `PRODUTO` (regra vai depender do item) ou `PESSOA` (regra vai depender do destinatário).
+2. ☐ Preencher **Descrição** (até 80 caracteres, obrigatório). Pode repetir entre Tipos diferentes.
+3. ☐ Em `Configurações`, clicar **Inserir** para criar a primeira linha de detalhe.
+4. ☐ Definir os filtros: `Nº Lojas`, `Sigla Estados`, `CNAE - Fiscal`, `Indicador IE`, `Atividade Comercial`, `Regime Tributário`. Vazio ou `-1` = qualquer.
+5. ☐ Escolher o **Cálculo** (`Normal` ou `Industria MT`).
+6. ☐ Marcar o **Tipo** (Saída ou Entrada) e a localização (`Dentro do Estado`, `Fora do Estado`, `Exterior`).
+7. ☐ Informar **B.C. ICMS ST** (% da base após redução), **MVA** (% de agregação) e **ICMS ST Aliq.** (% da alíquota).
+8. ☐ Se a MVA já está mantida no NCM dos itens, marcar **Usar MVA NCM** para o sistema buscar lá.
+9. ☐ Clicar **Atualizar** para gravar a linha de detalhe.
+10. ☐ Repetir os passos 3–9 para cada contexto que precisa de regra própria.
+11. ☐ Salvar o cadastro completo no botão `Salvar` da barra inferior.
+12. ☐ Vincular a Região no cadastro de **Produtos** (Tipo `PRODUTO`) ou no cadastro de **Pessoas** (Tipo `PESSOA`).
+
+---
+
+## 🧮 Anatomia da tela
+
+| Bloco | O que define |
+|---|---|
+| **Cabeçalho** | Identidade da regra: `Tipo` (PRODUTO/PESSOA) + `Descrição`. |
+| **Configurações** (sub-CRUD com Inserir / Atualizar / Deletar / Cancelar) | Linhas com filtros de contexto + percentuais de ICMS-ST + modo de cálculo. |
+
+---
+
+## ✏️ Operações no detalhe
+
+| Botão | Quando usar |
+|---|---|
+| **Inserir** | Iniciar uma nova linha de detalhe. Foca em `Nº Lojas` e habilita a edição. |
+| **Atualizar** | Gravar as alterações da linha em edição. Roda as validações antes de aceitar. |
+| **Deletar** | Excluir a linha atualmente selecionada (pede confirmação). |
+| **Cancelar** | Descartar as alterações da linha em edição e voltar ao estado anterior (pede confirmação). |
+
+---
+
+## 🧷 Atalhos de listas
+
+| Campo | Formato | Exemplo |
+|---|---|---|
+| Nº Lojas | Códigos de filial separados por `/` | `/1/2/` |
+| Sigla Estados | UFs separadas por `/` | `/BA/SP/MG/` |
+| CNAE - Fiscal | Selecionado por busca (duplo clique ou tecla de busca) | — |
+
+O Sol.NET adiciona automaticamente as barras `/` no início e no fim ao sair do campo.
+
+---
+
+## 🚨 Erros mais comuns
+
+| Mensagem / sintoma | Diagnóstico rápido |
+|---|---|
+| *"Não permitido, Existe Produto(s) com essa Região!"* | A Região (Tipo `PRODUTO`) está vinculada a produtos. Abra o cadastro dos produtos, troque a Região e tente excluir novamente. |
+| *"Existe cadastro em edição"* ao trocar de seção | Há uma linha de detalhe sendo inserida sem confirmação. Clique `Atualizar` para gravar ou `Cancelar` para descartar. |
+| ICMS-ST do movimento não bate com o esperado | Conferir, na ordem: (1) Tipo da Região vinculada (PRODUTO × PESSOA), (2) qual linha do detalhe casa com o contexto do movimento, (3) se o modo é `Normal` ou `Industria MT`, (4) se `Usar MVA NCM` está marcado e se o NCM tem MVA. |
+| Linha gravada mas não aplica em movimento de fora do estado | Confirme o radio `Selecione`: precisa estar `Fora do Estado` para operações interestaduais. |
+| MVA da linha ignorada no cálculo | O `Usar MVA NCM` está marcado — o sistema buscou a MVA no NCM do item. |
+
+---
+
+## 📎 Telas relacionadas
+
+- `Cadastro de NCM` (`21`) — fonte da MVA quando `Usar MVA NCM` está marcado.
+- `Cadastro de Produtos` (`32`) — onde a Região do tipo `PRODUTO` é vinculada.
+- `Cadastro de Pessoas` (`5`) — onde a Região do tipo `PESSOA` é vinculada.
+- `Cadastro de CNAE` (`156`) — origem da busca do campo `CNAE - Fiscal`.
+- `Região ICMS Saída` (`93`) — regra paralela para ICMS normal (Natureza de Operação por contexto).
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 1.0
+**Público-alvo**: Equipe de Suporte / Usuários do Sol.NET

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -203,6 +203,57 @@
         color: var(--sn-sidebar-accent);
       }
 
+      /* ---------- Sub-sub-grupo (3º nível, ex.: cadastro dentro de Cadastros Fiscais) ---------- */
+      .sn-sidebar__subgroup2 { margin: 0; }
+      .sn-sidebar__subgroup2-summary {
+        list-style: none;
+        cursor: pointer;
+        padding: 6px 20px 6px 52px;
+        color: var(--sn-sidebar-text);
+        font-weight: 500;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        user-select: none;
+        font-size: 13px;
+        line-height: 1.35;
+      }
+      .sn-sidebar__subgroup2-summary::-webkit-details-marker { display: none; }
+      .sn-sidebar__subgroup2-summary::before {
+        content: "▸";
+        font-size: 9px;
+        color: var(--sn-sidebar-muted);
+        transition: transform 0.15s ease;
+        display: inline-block;
+        width: 9px;
+      }
+      .sn-sidebar__subgroup2[open] > .sn-sidebar__subgroup2-summary::before {
+        transform: rotate(90deg);
+      }
+      .sn-sidebar__subgroup2-summary:hover { background: var(--sn-sidebar-hover-bg); }
+      .sn-sidebar__subitems2 {
+        list-style: none;
+        margin: 0;
+        padding: 2px 0 4px;
+      }
+      .sn-sidebar__subitems2 li { margin: 0; }
+      .sn-sidebar__subitems2 a {
+        display: block;
+        padding: 4px 20px 4px 76px;
+        text-decoration: none;
+        color: var(--sn-sidebar-text);
+        border-left: 3px solid transparent;
+        line-height: 1.35;
+        font-size: 13px;
+      }
+      .sn-sidebar__subitems2 a:hover { background: var(--sn-sidebar-hover-bg); }
+      .sn-sidebar__subitems2 a.is-active {
+        background: var(--sn-sidebar-active-bg);
+        border-left-color: var(--sn-sidebar-accent);
+        font-weight: 600;
+        color: var(--sn-sidebar-accent);
+      }
+
       .sn-sidebar__footer {
         padding: 12px 20px 20px;
         font-size: 11px;
@@ -496,15 +547,46 @@
                 <details class="sn-sidebar__subgroup" data-sn-subgroup="cadastros-fiscais">
                   <summary class="sn-sidebar__subgroup-summary">Cadastros Fiscais</summary>
                   <ul class="sn-sidebar__subitems">
-                    <li><a href="{{ '/Fiscal/documentacao_ncm/' | relative_url }}">NCM — Documentação</a></li>
-                    <li><a href="{{ '/Fiscal/guia_rapido_ncm/' | relative_url }}">NCM — Guia Rápido</a></li>
-                    <li><a href="{{ '/Fiscal/faq_ncm/' | relative_url }}">NCM — FAQ</a></li>
-                    <li><a href="{{ '/Fiscal/documentacao_regiao_icms/' | relative_url }}">Região ICMS Saída — Documentação</a></li>
-                    <li><a href="{{ '/Fiscal/guia_rapido_regiao_icms/' | relative_url }}">Região ICMS Saída — Guia Rápido</a></li>
-                    <li><a href="{{ '/Fiscal/faq_regiao_icms/' | relative_url }}">Região ICMS Saída — FAQ</a></li>
-                    <li><a href="{{ '/Fiscal/documentacao_natureza_operacao/' | relative_url }}">Natureza de Operação — Documentação</a></li>
-                    <li><a href="{{ '/Fiscal/guia_rapido_natureza_operacao/' | relative_url }}">Natureza de Operação — Guia Rápido</a></li>
-                    <li><a href="{{ '/Fiscal/faq_natureza_operacao/' | relative_url }}">Natureza de Operação — FAQ</a></li>
+                    <li>
+                      <details class="sn-sidebar__subgroup2" data-sn-subgroup2="ncm">
+                        <summary class="sn-sidebar__subgroup2-summary">NCM</summary>
+                        <ul class="sn-sidebar__subitems2">
+                          <li><a href="{{ '/Fiscal/documentacao_ncm/' | relative_url }}">Documentação</a></li>
+                          <li><a href="{{ '/Fiscal/guia_rapido_ncm/' | relative_url }}">Guia Rápido</a></li>
+                          <li><a href="{{ '/Fiscal/faq_ncm/' | relative_url }}">FAQ</a></li>
+                        </ul>
+                      </details>
+                    </li>
+                    <li>
+                      <details class="sn-sidebar__subgroup2" data-sn-subgroup2="regiao-icms-saida">
+                        <summary class="sn-sidebar__subgroup2-summary">Região ICMS Saída</summary>
+                        <ul class="sn-sidebar__subitems2">
+                          <li><a href="{{ '/Fiscal/documentacao_regiao_icms/' | relative_url }}">Documentação</a></li>
+                          <li><a href="{{ '/Fiscal/guia_rapido_regiao_icms/' | relative_url }}">Guia Rápido</a></li>
+                          <li><a href="{{ '/Fiscal/faq_regiao_icms/' | relative_url }}">FAQ</a></li>
+                        </ul>
+                      </details>
+                    </li>
+                    <li>
+                      <details class="sn-sidebar__subgroup2" data-sn-subgroup2="regiao-icms-st-saida">
+                        <summary class="sn-sidebar__subgroup2-summary">Região ICMS ST Saída</summary>
+                        <ul class="sn-sidebar__subitems2">
+                          <li><a href="{{ '/Fiscal/documentacao_regiao_icms_st_saida/' | relative_url }}">Documentação</a></li>
+                          <li><a href="{{ '/Fiscal/guia_rapido_regiao_icms_st_saida/' | relative_url }}">Guia Rápido</a></li>
+                          <li><a href="{{ '/Fiscal/faq_regiao_icms_st_saida/' | relative_url }}">FAQ</a></li>
+                        </ul>
+                      </details>
+                    </li>
+                    <li>
+                      <details class="sn-sidebar__subgroup2" data-sn-subgroup2="natureza-operacao">
+                        <summary class="sn-sidebar__subgroup2-summary">Natureza de Operação</summary>
+                        <ul class="sn-sidebar__subitems2">
+                          <li><a href="{{ '/Fiscal/documentacao_natureza_operacao/' | relative_url }}">Documentação</a></li>
+                          <li><a href="{{ '/Fiscal/guia_rapido_natureza_operacao/' | relative_url }}">Guia Rápido</a></li>
+                          <li><a href="{{ '/Fiscal/faq_natureza_operacao/' | relative_url }}">FAQ</a></li>
+                        </ul>
+                      </details>
+                    </li>
                   </ul>
                 </details>
               </li>
@@ -702,7 +784,7 @@
         var activeLink = null;
         var bestLength = -1;
 
-        var links = sidebar.querySelectorAll('.sn-sidebar__items a, .sn-sidebar__subitems a, .sn-sidebar__home');
+        var links = sidebar.querySelectorAll('.sn-sidebar__items a, .sn-sidebar__subitems a, .sn-sidebar__subitems2 a, .sn-sidebar__home');
         links.forEach(function (a) {
           var hrefPath;
           try { hrefPath = new URL(a.href, window.location.href).pathname; }

--- a/llms.txt
+++ b/llms.txt
@@ -43,6 +43,9 @@ Toda tela do Sol.NET é acessada pela pesquisa universal (atalho `F1`), digitand
 - [Natureza de Operação — Documentação](https://hetosoft.github.io/documentacao-solnet/Fiscal/documentacao_natureza_operacao/): tela Natureza de Operação (código 36) — cadastro central com CFOP, ICMS, PIS/COFINS, CBS/IBS, mapeamento de CFOP para importação de XML e flags de override sobre Região ICMS.
 - [Natureza de Operação — Guia Rápido](https://hetosoft.github.io/documentacao-solnet/Fiscal/guia_rapido_natureza_operacao/): checklists para Saída e Entrada, autocomplete do CFOP e soluções rápidas para erros recorrentes.
 - [Natureza de Operação — FAQ](https://hetosoft.github.io/documentacao-solnet/Fiscal/faq_natureza_operacao/): conceito, autocomplete, regras fiscais, flags Manter, Importar XML e aplicação no movimento.
+- [Região ICMS ST Saída — Documentação](https://hetosoft.github.io/documentacao-solnet/Fiscal/documentacao_regiao_icms_st_saida/): tela Região ICMS ST Saída (código 94) — percentuais diretos de Base, MVA e alíquota de ICMS-ST por contexto, vínculo por Produto ou Pessoa, `Usar MVA NCM` e modo `Industria MT`.
+- [Região ICMS ST Saída — Guia Rápido](https://hetosoft.github.io/documentacao-solnet/Fiscal/guia_rapido_regiao_icms_st_saida/): checklist de cadastro, anatomia da tela, formato das listas de lojas e estados, operações do detalhe e erros recorrentes.
+- [Região ICMS ST Saída — FAQ](https://hetosoft.github.io/documentacao-solnet/Fiscal/faq_regiao_icms_st_saida/): diferença para a 93, escolha entre Tipo PRODUTO e PESSOA, papel do Usar MVA NCM, quando usar Industria MT e desbloqueio de exclusão.
 
 ## Movimentação
 


### PR DESCRIPTION
## Resumo

Cria o trio de páginas da tela **Região ICMS ST Saída** (`94`, `FrmCadastroRegiaoICMSST`) no módulo Fiscal, fechando o subgrupo `Cadastros Fiscais`. Também reestrutura o subgrupo na sidebar: cada cadastro agora é um sub-`<details>` próprio com 3 itens (Documentação / Guia Rápido / FAQ), em vez de uma lista plana de 9 itens.

## Arquivos novos

- `Fiscal/documentacao_regiao_icms_st_saida.md` (v1.0)
- `Fiscal/guia_rapido_regiao_icms_st_saida.md` (v1.0)
- `Fiscal/faq_regiao_icms_st_saida.md` (v1.0)

## Arquivos alterados

- `Fiscal/README.md` — adiciona as 3 entradas do trio e sobe a versão `1.6` → `1.7`.
- `_layouts/default.html` — reestrutura o HTML do subgrupo `Cadastros Fiscais` em sub-details aninhados, adiciona CSS para o terceiro nível (`.sn-sidebar__subgroup2` / `.sn-sidebar__subitems2`) e estende o seletor do script de ativação para que links do 3º nível recebam `is-active`.
- `llms.txt` — 3 novas entradas na seção Fiscal.

## Códigos de tela referenciados

- `94` — Região ICMS ST Saída
- `93` — Região ICMS Saída (comparação)
- `36` — Natureza de Operação (comparação)
- `21` — NCM (relação com `Usar MVA NCM`)
- `5` — Pessoas (vínculo Tipo `PESSOA`)
- `32` — Produtos (vínculo Tipo `PRODUTO`)
- `156` — CNAE (busca do campo `CNAE - Fiscal`)

Códigos confirmados na tabela `FORMULARIO` do banco antes da escrita.

## Fontes usadas

- `Sol.NET/Form/uFrmCadastroRegiaoICMSST.dfm` (Captions reais e mapeamentos `AHS_ClientDataSetCampo`)
- `Sol.NET/Form/uFrmCadastroRegiaoICMSST.pas` (validações: bloqueio de exclusão por produto vinculado, normalização de listas, ausência de checagem de descrição duplicada)
- Schema das tabelas `REGIAO_ICMSST` e `REGIAO_ICMSST_DETALHES` no banco `Concordia`
- Esclarecimentos do usuário: significado do item descontinuado em `Cálculo`, contexto do `Industria MT`, hints duplos em `MVA`/`ICMS ST Aliq.`, papel do `Usar MVA NCM`, semântica do Tipo `PESSOA`