### PR TITLE
docs: núcleo conceitual do portal + trilhas operacionais de Movimentação

### DIFF
--- a/Movimentacao/Movimentos/documentacao_movimentos.md
+++ b/Movimentacao/Movimentos/documentacao_movimentos.md
@@ -144,7 +144,7 @@ Aciona a transmissão fiscal do documento eletrônico. O sistema gera o XML, ass
 
 ### Estornar (botão **Estornar** / `F11`)
 
-Reverte completamente o efeito do movimento — devolve saldo ao estoque, cancela financeiro, cancela documento fiscal (quando permitido pela SEFAZ). A reversão é registrada e gera trilha de auditoria visível em `Histórico de Movimentações` (código `205`).
+Reverte completamente o efeito do movimento — devolve saldo ao estoque, cancela financeiro, cancela documento fiscal (quando permitido pela SEFAZ). O movimento estornado aparece nos relatórios de movimentação como estornado/cancelado, e pode ser filtrado por `Status` em `Histórico de Movimentações` (código `205`).
 
 ---
 
@@ -233,8 +233,8 @@ A `Transação de Estoque` amarrada ao Tipo não está configurada para subtrair
 **O combo `Tipo de Movimento` não mostra o Tipo que preciso.**
 O Tipo está inativo, ou está com Comportamento incompatível com a tela aberta (Entrada → `201`, Saída → `202`, Outros → `203`), ou o usuário não tem permissão no grupo de acesso desse Tipo.
 
-**Onde vejo o histórico completo das alterações deste movimento?**
-Em [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (código `205`) — todas as operações (gravação, edição, finalização, mudança, quitação, estorno, transmissão fiscal) ficam registradas com data, hora e usuário.
+**Onde vejo o histórico de alterações deste movimento (quem alterou, quando)?**
+O Sol.NET **não tem tela dedicada** a esse tipo de trilha de auditoria — a `Histórico de Movimentações` (código `205`) lista os movimentos e seus dados atuais, com filtros e totais (vendas, devoluções, comissões), mas não preserva quem alterou cada campo ao longo do tempo. Para reconstituir o que mudou, a alternativa prática é consultar a tela `205` para o estado atual e, em casos críticos, abrir chamado de suporte para investigação direta no banco.
 
 **Lancei na tela errada (compra na `202` em vez de `201`).**
 Não há como lançar na tela errada, na verdade — o filtro de Tipos por Comportamento impede. Se a sensação é que o Tipo deveria estar disponível em outra tela, é a **configuração do Tipo** em `37` que está com Comportamento divergente. Ajuste lá.
@@ -252,7 +252,7 @@ Mais perguntas e a referência completa de mensagens de erro em [FAQ](faq.md).
 | [Locais de Estoque](../documentacao_locais_de_estoque.md) | `28` | Identifica em qual armazém/loja o saldo afetado vive. Cabeçalho exige Local quando o Tipo movimenta estoque. |
 | [Tabela de Preço](../documentacao_tabela_de_preco.md) | `27` | Origem do `Preço` aplicado a cada item no Cabeçalho/Itens. |
 | [Saldo Estoque](../documentacao_saldo_estoque.md) | `78` | Visão consolidada do efeito dos movimentos nos saldos por Local/Situação. |
-| [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) | `205` | Trilha de auditoria do que aconteceu com cada movimento. |
+| [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) | `205` | Análise e totais de movimentos — por dia, mês, pessoa, tipo, portador, condição, vendedor, operador, tabela; cálculo de comissões. |
 | [Histórico de Produtos](../documentacao_historico_de_produtos.md) | `206` | Filtra por produto — vê quais movimentos afetaram cada item. |
 | [Ajuste de Estoque](../documentacao_ajuste_de_estoque.md) | `79` | Tela auxiliar que **dispara** movimentos visíveis em `203`. |
 | `Pedido de Compra` | `64` | Tela que **dispara** movimentos em `201` ao ser convertido em entrada. |
@@ -272,5 +272,5 @@ Mais perguntas e a referência completa de mensagens de erro em [FAQ](faq.md).
 ---
 
 **Última atualização**: Maio de 2026
-**Versão**: 5.0
+**Versão**: 5.1
 **Público-alvo**: Usuários operacionais (caixa, frente de loja, retaguarda) / Suporte

--- a/Movimentacao/Movimentos/faq.md
+++ b/Movimentacao/Movimentos/faq.md
@@ -104,9 +104,9 @@ Verifique nesta ordem:
 
 A `Transação de Estoque` amarrada ao Tipo não está configurada para subtrair as camadas certas (`Físico`, `Disponível`). Abra [Transações de Estoque](../documentacao_transacoes_de_estoque.md) (`33`), localize a Transação amarrada ao Tipo do movimento e confira os marcadores. Verifique também o `Local de Estoque` informado no Cabeçalho — o saldo é por Local, e às vezes o que parece "não baixou" é "baixou no Local errado".
 
-### Onde vejo o histórico completo de alterações deste movimento?
+### Onde vejo o histórico de alterações deste movimento (quem alterou, quando)?
 
-Em [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) — toda gravação, edição, finalização, mudança de Tipo, quitação, transmissão fiscal e estorno fica registrada com data, hora e usuário.
+O Sol.NET **não tem tela dedicada** a esse tipo de trilha de auditoria. A tela [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) lista os movimentos e seus dados atuais com filtros e totais (vendas, devoluções, comissões), mas não preserva o histórico de quem alterou cada campo ao longo do tempo. Para reconstituir alterações em casos críticos, abra chamado de suporte para investigação direta no banco.
 
 ### Como repor um movimento estornado?
 
@@ -148,5 +148,5 @@ Aparece quando o movimento foi origem de uma **Mudança Duplicar** (`F7` com o T
 ---
 
 **Última atualização**: Maio de 2026
-**Versão**: 5.0
+**Versão**: 5.1
 **Público-alvo**: Usuários operacionais / Equipe de Suporte / Consultores de Implantação Sol.NET

--- a/Movimentacao/Movimentos/movimentos_de_compras.md
+++ b/Movimentacao/Movimentos/movimentos_de_compras.md
@@ -63,10 +63,10 @@ Outras referências úteis:
 
 - [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) — onde os Tipos de Entrada são configurados.
 - [Transações de Estoque](../documentacao_transacoes_de_estoque.md) (`33`) — efeito da entrada nas camadas de saldo.
-- [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) — trilha de auditoria.
+- [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) — análise e totais de compras por período, fornecedor, portador.
 
 ---
 
 **Última atualização**: Maio de 2026
-**Versão**: 5.0
+**Versão**: 5.1
 **Público-alvo**: Equipe de recebimento / Retaguarda fiscal / Suporte

--- a/Movimentacao/Movimentos/movimentos_de_vendas.md
+++ b/Movimentacao/Movimentos/movimentos_de_vendas.md
@@ -74,10 +74,10 @@ Outras referências úteis:
 - [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) — onde os Tipos de Saída são configurados.
 - [Tabela de Preço](../documentacao_tabela_de_preco.md) (`27`) — origem do preço aplicado a cada item.
 - [Regras Cashback](../documentacao_regras_cashback.md) (`124`) — regras de cashback (uso/geração) configuradas por Tipo; movimentos do PDV chegam aqui com o cashback já aplicado.
-- [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) — trilha de auditoria.
+- [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) — análise e totais de vendas por período, vendedor, portador, condição, tabela; cálculo de comissões.
 
 ---
 
 **Última atualização**: Maio de 2026
-**Versão**: 5.0
+**Versão**: 5.1
 **Público-alvo**: Vendedores de balcão / Retaguarda comercial / Suporte

--- a/Movimentacao/Movimentos/outros_movimentos.md
+++ b/Movimentacao/Movimentos/outros_movimentos.md
@@ -97,10 +97,10 @@ Outras referências úteis:
 - [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) — onde os Tipos `Outros` são configurados.
 - [Ajuste de Estoque](../documentacao_ajuste_de_estoque.md) (`79`) — telas auxiliares que disparam movimentos aqui.
 - [Produção de Produtos](../Producao/documentacao_producao_de_produtos.md) (`144`) — idem.
-- [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) — trilha de auditoria.
+- [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) — análise e totais dos movimentos lançados aqui.
 
 ---
 
 **Última atualização**: Maio de 2026
-**Versão**: 5.0
+**Versão**: 5.1
 **Público-alvo**: Retaguarda de estoque / Logística / Suporte

--- a/Movimentacao/README.md
+++ b/Movimentacao/README.md
@@ -5,6 +5,19 @@ permalink: /Movimentacao/
 
 # 📚 Documentação do Módulo Movimentação — Sol.NET
 
+## 🛤️ Comece pelas trilhas
+
+Se sua demanda é **executar algo ponta a ponta** — em vez de aprender uma tela isolada — vá direto para uma das [Trilhas operacionais](Trilhas/):
+
+- [Entrada de NF-e completa](Trilhas/trilha_entrada_nfe.md) — Manifestação → Importar XML → Conferência → `201` → estoque + financeiro.
+- [Venda completa](Trilhas/trilha_venda_completa.md) — `202` → emissão fiscal → Quitação.
+- [Devolução de venda](Trilhas/trilha_devolucao_venda.md) — `203` com Tipo `Devolução de Venda` + referência à nota original.
+- [Ajuste de estoque com auditoria](Trilhas/trilha_ajuste_estoque_auditoria.md) — `79` → `203` → auditar em `206` / `78`.
+
+Quando uma mensagem aparecer e você não souber por onde começar a resolver, use o [Índice unificado de mensagens](indice_mensagens.md).
+
+---
+
 > 🚧 **Em reescrita.** O conteúdo anterior deste módulo foi descartado e está sendo refeito do zero, no mesmo padrão usado em [Financeiro](../Financeiro/) — uma página por tela, ancorada no código-fonte e em consultas ao banco. Novos documentos são listados aqui à medida que forem publicados. Dúvidas pontuais sobre telas ainda não cobertas podem ser respondidas pelo suporte Hetosoft.
 
 ---

--- a/Movimentacao/Trilhas/README.md
+++ b/Movimentacao/Trilhas/README.md
@@ -1,0 +1,53 @@
+---
+title: "Índice: Trilhas operacionais — Sol.NET"
+permalink: /Movimentacao/Trilhas/
+---
+
+# 🛤️ Trilhas operacionais — Sol.NET
+
+## 🎯 Visão Geral
+
+As **trilhas** são guias narrativos que atravessam **várias telas em sequência** para cobrir uma demanda real do dia a dia — uma entrada de NF-e completa, uma venda do começo ao fim, uma devolução, um ajuste com auditoria. Cada trilha mostra o caminho que liga as telas, o que esperar em cada etapa e onde os erros costumam aparecer.
+
+> 💡 **Quando usar uma trilha vs. uma documentação de tela.** A documentação de cada tela responde "como esta tela funciona". A trilha responde "como cumpro esta demanda do começo ao fim". Use a trilha quando estiver executando uma tarefa real; volte para a documentação da tela quando precisar de detalhes específicos de um campo ou validação.
+
+---
+
+## 📄 Trilhas publicadas
+
+| Trilha | Demanda que resolve | Telas envolvidas |
+|---|---|---|
+| [Entrada de NF-e completa](trilha_entrada_nfe.md) | Recebi uma NF-e do fornecedor — preciso manifestar, conferir, lançar e gerar o financeiro. | Manifestação (`401`) → Importar XML (`204`) → Conferência → Movimentos de Compras (`201`) |
+| [Venda completa](trilha_venda_completa.md) | Quero vender, emitir documento fiscal e quitar — do orçamento ou venda direta até a baixa do título. | Movimentos de Vendas (`202`) → emissão fiscal → Quitação (`303`) |
+| [Devolução de venda](trilha_devolucao_venda.md) | Cliente devolveu mercadoria — preciso registrar a volta no estoque, emitir fiscal de devolução e gerar crédito. | Movimentos de Vendas (`202`, consulta da venda original) → Outros Movimentos (`203`) |
+| [Ajuste de estoque com auditoria](trilha_ajuste_estoque_auditoria.md) | Preciso corrigir saldo de produtos e conseguir auditar o ajuste depois. | Ajuste de Estoque (`79`) → Outros Movimentos (`203`) → Histórico de Produtos (`206`) / Transações de Estoque (`33`) |
+
+---
+
+## 📌 Como ler uma trilha
+
+Cada trilha segue a mesma estrutura:
+
+1. **Diagrama de fluxo** — mapa visual das telas pela ordem.
+2. **Passos** — cada passo nomeia a tela, código F1 e o que fazer.
+3. **O que esperar como resultado** — em estoque, financeiro e fiscal.
+4. **Quando dá errado** — mensagens comuns e link para o [índice unificado de mensagens](../indice_mensagens.md).
+5. **Para aprofundar** — links para a documentação completa das telas envolvidas.
+
+---
+
+## 🗺️ Outras formas de entrar
+
+| Quer | Vá para |
+|---|---|
+| Entender o modelo mental antes de qualquer operação | [Visão geral do Sol.NET](../../visao_geral_sol_net.md) |
+| Definir o vocabulário (Movimento, Tipo, Transação, Faturar, Quitar…) | [Glossário](../../glossario.md) |
+| Resolver uma dúvida específica por tarefa ("Quero…") | [Índice por tarefa](../../quero.md) |
+| Ler a referência completa do trio Movimentos `201/202/203` | [Movimentos — referência](../Movimentos/documentacao_movimentos.md) |
+| Configurar como um Tipo de Movimento se comporta | [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) |
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 1.0
+**Público-alvo**: Usuários operacionais / Retaguarda / Suporte

--- a/Movimentacao/Trilhas/trilha_ajuste_estoque_auditoria.md
+++ b/Movimentacao/Trilhas/trilha_ajuste_estoque_auditoria.md
@@ -1,0 +1,170 @@
+# 📄 Trilha — Ajuste de estoque com auditoria - Sol.NET
+
+## 🎯 Visão Geral
+
+Trilha narrativa que cobre o ciclo completo de **um ajuste de saldo** com auditoria posterior — desde a contagem física até a inspeção dos movimentos gerados e a confirmação do novo saldo.
+
+Esta trilha atravessa:
+
+- [Ajuste de Estoque](../documentacao_ajuste_de_estoque.md) (`79`) — onde a contagem é registrada e o ajuste é disparado.
+- [Outros Movimentos](../Movimentos/outros_movimentos.md) (`203`) — onde os movimentos gerados pelo ajuste aparecem.
+- [Histórico de Produtos](../documentacao_historico_de_produtos.md) (`206`) — auditoria por produto.
+- [Saldo Estoque](../documentacao_saldo_estoque.md) (`78`) — confirmação do novo saldo.
+- [Transações de Estoque](../documentacao_transacoes_de_estoque.md) (`33`) — referência das regras das camadas afetadas.
+
+> 💡 **Por que essa trilha existe.** Mexer direto no estoque é fácil de fazer e impossível de auditar. O caminho padrão e auditável no Sol.NET é o `Ajuste de Estoque` (`79`) — ele registra a contagem, dispara movimentos rastreáveis e mantém o vínculo (`ID_AJUSTE_SALDO`) entre o ajuste e os movimentos gerados.
+
+---
+
+## 🗺️ Fluxo completo
+
+```mermaid
+flowchart TD
+  C[1 - Preparar ajuste<br/>Ajuste de Estoque 79] --> Cont[2 - Lançar contagem<br/>e calcular diferença]
+  Cont --> Cri[3 - Criar Ajustes]
+  Cri --> Mov[(Movimentos gerados em 203<br/>vinculados por ID_AJUSTE_SALDO)]
+  Mov --> Aud1[4 - Auditar por produto<br/>Histórico de Produtos 206]
+  Mov --> Aud2[4 - Auditar saldo final<br/>Saldo Estoque 78]
+```
+
+---
+
+## 1️⃣ Preparar o ajuste — tela [Ajuste de Estoque](../documentacao_ajuste_de_estoque.md) (`79`)
+
+**O que fazer:**
+
+1. Abra a pesquisa (`F1`) e digite `79`.
+2. Clique em **Novo**.
+3. Preencha o cabeçalho:
+   - `Descrição` — nome livre que identifique o ajuste (`INVENTÁRIO OUT/2026 — LOJA CENTRAL`, `CORREÇÃO SEÇÃO BEBIDAS`).
+   - `Data` — data da contagem física.
+   - `Descrição da Loja` — a empresa.
+   - `Local de Estoque` — local físico do saldo a corrigir (`LOJA`, `DEPÓSITO`).
+   - `Situação do Estoque` — camada afetada (geralmente `FISICO`).
+   - `Tipo de Movimento — Entrada` — Tipo configurado para gerar movimentos quando a diferença é positiva.
+   - `Tipo de Movimento — Saída` — Tipo configurado para gerar movimentos quando a diferença é negativa.
+
+> ⚠️ **Acesso de suporte necessário:** os Tipos de Movimento usados como Entrada e Saída do ajuste vêm do `Cadastro de Tipos de Movimento` (código `37`), que requer permissão de acesso de suporte. Entre em contato com o suporte Hetosoft antes de criar ou alterar Tipos de Movimento dedicados a ajustes de estoque.
+
+---
+
+## 2️⃣ Lançar a contagem e calcular a diferença
+
+**O que fazer:**
+
+1. Na grid de produtos do ajuste, adicione os produtos a inventariar:
+   - **Um por um:** botão `Inserir` → busca → confirma.
+   - **Em lote:** menu de contexto da grid → `Adicionar Produtos` → filtre por família/grupo → `Selecionar Todos`.
+   - **Em massa por leitura:** configure `Comportamentos → Modo Adicionar Itens` para leitura de código de barras.
+2. Para cada linha, a coluna `Saldo Atual` aparece preenchida automaticamente (saldo registrado no banco no momento da inclusão).
+3. Faça a contagem física (manual, com coletor, com inventariante).
+4. Digite o valor medido na coluna `Contagem`. O sistema calcula `Diferença = Contagem - Saldo Atual` automaticamente:
+   - **Positiva** — sobrou no físico; vai gerar movimento de entrada.
+   - **Negativa** — faltou no físico; vai gerar movimento de saída.
+   - **Zero** — confere; nenhum movimento gerado para essa linha.
+
+**Resultado esperado:** grid com `Contagem` preenchida em todas as linhas, `Diferença` calculada e ajuste em status `ABERTO`.
+
+---
+
+## 3️⃣ Disparar a criação dos movimentos — botão `Criar Ajustes`
+
+**O que fazer:**
+
+1. Clique em **`Criar Ajustes`**.
+2. Para cada linha com `Diferença ≠ 0`, o Sol.NET cria automaticamente um movimento em [Outros Movimentos](../Movimentos/outros_movimentos.md) (`203`):
+   - Se `Diferença > 0`, usa o Tipo `Entrada` configurado no cabeçalho.
+   - Se `Diferença < 0`, usa o Tipo `Saída` configurado.
+3. Os movimentos ficam vinculados ao ajuste pelo campo interno `ID_AJUSTE_SALDO`.
+4. O status do ajuste muda de `ABERTO` para processado, bloqueando alterações posteriores.
+
+**Resultado esperado:**
+
+- **Aba `Movimentos`** do ajuste — lista os IDs dos movimentos criados.
+- **Estoque** — saldo corrigido para refletir a contagem.
+- **Auditoria** — vínculo `ID_AJUSTE_SALDO` permanece em cada movimento, permitindo rastrear posteriormente qual ajuste originou cada correção.
+
+---
+
+## 4️⃣ Auditar o ajuste depois
+
+A auditoria pode ser feita de três ângulos complementares:
+
+### Por produto — tela [Histórico de Produtos](../documentacao_historico_de_produtos.md) (`206`)
+
+Mostra **cada movimento que tocou o saldo daquele produto**, em ordem. Útil para responder "por que o saldo do produto X mudou nessa data?".
+
+1. Abra `F1` → `206`.
+2. Filtre pelo produto e/ou período.
+3. Os movimentos gerados pelo ajuste aparecem com o Tipo configurado (Entrada ou Saída).
+4. Para abrir o detalhe de um movimento, navegue para `203` e localize pelo ID.
+
+### Por saldo final — tela [Saldo Estoque](../documentacao_saldo_estoque.md) (`78`)
+
+Confirma o **novo saldo** após o ajuste.
+
+1. Abra `F1` → `78`.
+2. Filtre pelo produto e/ou Local.
+3. Confira o saldo nas camadas afetadas (geralmente `Físico` e `Disponível`).
+
+### Pelas regras das camadas — tela [Transações de Estoque](../documentacao_transacoes_de_estoque.md) (`33`)
+
+Útil para entender **em quais camadas o ajuste mexeu**. Cada Tipo de Movimento aponta para uma Transação que decide o efeito por camada.
+
+1. Abra `F1` → `33`.
+2. Localize a Transação amarrada ao Tipo usado no ajuste.
+3. Confira as colunas `Físico`, `Disponível`, `Reservado` para entender quais camadas foram alteradas.
+
+---
+
+## ⚠️ Quando dá errado
+
+| Mensagem | Etapa | Onde resolver |
+|---|---|---|
+| `Ajuste de Estoque sem Produtos!` | 3 | Grid vazia. Adicione produtos antes de clicar em `Criar Ajustes`. |
+| `Não Permitido! Só Status Aberto.` | 2 | Tentou editar um ajuste já processado. Ajustes processados são imutáveis — crie um novo ajuste com a contagem invertida para corrigir. |
+| `Produto Configurado para 'Não Movimentar Estoque'!` | 2 | Produto está marcado para não movimentar no [Cadastro de Produtos](../../Produtos/documentacao_produtos.md) (`32`). Ajustar o cadastro primeiro, ou remover o produto do inventário. |
+| `Não Permitido, Quantidade Máxima Excedida (999.999,99)!` | 2 | Contagem digitada acima do limite. Verifique unidade — provavelmente está pesando em gramas o que deveria ser quilos. |
+| `Só com Status 'ABERTO'` ao tentar excluir | — | Ajuste já processado não pode ser excluído. Crie um novo ajuste com a contagem invertida. |
+| `Não permitido, Existe Movimento(s) Vinculado!` ao tentar excluir | — | Idem acima — há movimentos gerados a partir deste ajuste. Reverter por novo ajuste, não por exclusão. |
+
+Lista completa em [Índice de mensagens](../indice_mensagens.md).
+
+---
+
+## 💡 Exemplos práticos
+
+### Inventário mensal de uma loja
+
+`79` → `Novo` → cabeçalho com `Descrição = INVENTÁRIO OUT/2026 — LOJA CENTRAL`, `Local = LOJA` → menu de contexto → `Adicionar Produtos` → marca todos os produtos da loja → contagem física com coletor → digita `Contagem` em cada linha → `Criar Ajustes`. Auditoria posterior em `206` (por produto) e `78` (saldo final).
+
+### Inventário rotativo — só uma seção
+
+Cenário: inventário semanal por seção. `79` → `Novo` → descrição refletindo a seção (`INVENTÁRIO BEBIDAS — SEM 42`) → `Adicionar Produtos` filtrado por grupo `BEBIDAS` → `Selecionar Todos` → contagem → `Criar Ajustes`.
+
+### Correção pontual de um único produto
+
+Detectou divergência num produto específico. `79` → `Novo` → cabeçalho com descrição curta (`AJUSTE PONTUAL — PRODUTO X`) → `Inserir` → busca o produto → digita `Contagem` → `Atualizar` → `Criar Ajustes`.
+
+### Reversão de ajuste errado
+
+Errou a contagem e o ajuste já foi processado. **Não tente excluir** — não funciona. Crie um **novo ajuste** com a contagem corrigida; a `Diferença` do novo vai compensar o erro do anterior. Ambos ficam rastreáveis no histórico.
+
+---
+
+## 🔗 Para aprofundar
+
+| Tela / Doc | Quando consultar |
+|---|---|
+| [Ajuste de Estoque](../documentacao_ajuste_de_estoque.md) (`79`) | Detalhes da tela, comportamentos, painel `Estoque`, validações. |
+| [Outros Movimentos](../Movimentos/outros_movimentos.md) (`203`) | Onde os movimentos gerados pelo ajuste vivem. |
+| [Histórico de Produtos](../documentacao_historico_de_produtos.md) (`206`) | Auditoria por produto. |
+| [Saldo Estoque](../documentacao_saldo_estoque.md) (`78`) | Saldo final por produto × Local × camada. |
+| [Transações de Estoque](../documentacao_transacoes_de_estoque.md) (`33`) | Regras das camadas de saldo. |
+| [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) | Configuração dos Tipos `Entrada` e `Saída` usados pelo ajuste. |
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 1.0
+**Público-alvo**: Operação de estoque / Inventariante / Suporte

--- a/Movimentacao/Trilhas/trilha_devolucao_venda.md
+++ b/Movimentacao/Trilhas/trilha_devolucao_venda.md
@@ -1,0 +1,152 @@
+# 📄 Trilha — Devolução de venda - Sol.NET
+
+## 🎯 Visão Geral
+
+Trilha narrativa que cobre o ciclo completo de **uma devolução de mercadoria já vendida**: do recebimento da mercadoria de volta à emissão da NF-e de devolução e à geração do crédito ao cliente.
+
+> ℹ️ **Por que devolução de venda vai em `203` e não em `202`?** A divisão entre as três telas de movimento segue o **operador**, não só o sentido fiscal. Devolução de venda envolve mercadoria entrando de volta, mas é operada pela retaguarda — não pelo vendedor. Por isso fica em [Outros Movimentos](../Movimentos/outros_movimentos.md) (`203`), com Tipos configurados como `Devolução`.
+
+Esta trilha atravessa:
+
+- [Movimentos de Vendas](../Movimentos/movimentos_de_vendas.md) (`202`) — apenas para **consultar** a venda original.
+- [Outros Movimentos](../Movimentos/outros_movimentos.md) (`203`) — onde a devolução é lançada.
+
+Em lojas de balcão com volume alto, há também um padrão de **duas etapas** (pedido de devolução intermediário durante o dia + NF-e de devolução consolidada no fechamento) coberto ao final.
+
+---
+
+## 🗺️ Fluxo padrão (devolução direta)
+
+```mermaid
+flowchart TD
+  C([Cliente devolve<br/>com cupom/NF-e]) --> Loc[1 - Localizar a venda original<br/>Movimentos de Vendas 202]
+  Loc --> Lan[2 - Lançar devolução<br/>Outros Movimentos 203<br/>Tipo Devolução de Venda]
+  Lan --> Ref[3 - Referenciar nota original<br/>obrigatório]
+  Ref --> Fin[4 - Finalizar F6]
+  Fin --> Est[(Estoque volta)]
+  Fin --> Fis[(NF-e de devolução emitida)]
+  Fin --> Cred[(Crédito de Pessoa gerado<br/>se Devolução Crédito ativo)]
+```
+
+---
+
+## 1️⃣ Localizar a venda original — tela [Movimentos de Vendas](../Movimentos/movimentos_de_vendas.md) (`202`)
+
+Esta etapa é só de consulta — precisa dos dados da venda original para referenciar na devolução.
+
+**O que fazer:**
+
+1. Abra a pesquisa (`F1`) e digite `202`.
+2. Na sub-aba `Movimentos`, localize a venda original — filtre por `Pessoa` (cliente), `Período` ou `Nº Documento` do cupom/NF-e.
+3. Anote os dados que vão ser usados na referência: `Tipo`, `Série`, `Nº Documento`, `Chave de Acesso` (para NF-e/NFC-e), data e os itens devolvidos.
+
+> 💡 Vendas vindas do PDV (cupons NFC-e) aparecem nesta tela com filtros na sub-aba `Pesquisa PDV`. Devolução de cupom é o caso de uso mais comum — siga o padrão de duas etapas descrito mais abaixo.
+
+---
+
+## 2️⃣ Lançar a devolução — tela [Outros Movimentos](../Movimentos/outros_movimentos.md) (`203`)
+
+**O que fazer:**
+
+1. Abra a pesquisa (`F1`) e digite `203`.
+2. Clique em **Novo**.
+3. Na sub-aba `Cabeçalho`:
+   - `Tipo` = `DEVOLUÇÃO DE VENDA` (ou outro Tipo configurado em `37` com `Devolução = Sim`).
+   - `Pessoa` = o cliente que está devolvendo.
+   - `Local de Estoque` = onde a mercadoria devolvida vai entrar.
+4. Na sub-aba `Itens`, adicione os produtos devolvidos com as mesmas quantidades.
+
+---
+
+## 3️⃣ Referenciar a nota original (obrigatório)
+
+Sem referência à venda original, a finalização é bloqueada com:
+*"Não Permitido, Obrigatório Referenciar Nota! (Devolução)"*.
+
+**O que fazer:**
+
+1. Localize, no formulário, a sub-aba/grupo de referência (`Notas Referenciadas` ou equivalente conforme a versão).
+2. Aponte para a venda original — o vínculo pode ser pela busca da nota no Sol.NET (mesma empresa) ou pela chave de acesso da NFC-e/NF-e original.
+3. A referência deve ser da **mesma empresa**, caso contrário a validação bloqueia: *"Não Permitido, Obrigatório Referenciar Nota da Mesma Empresa! (Devolução)"*.
+
+---
+
+## 4️⃣ Finalizar — `F6`
+
+**O que fazer:**
+
+1. Pressione `F6` ou clique em `Finalizar`.
+2. O sistema valida CFOPs (devolução normalmente usa CFOPs `1202`/`2202`/`1410`/`2410`), totalizações, série e referência.
+
+**Resultado esperado:**
+
+- **Estoque** — soma na camada `Físico` e `Disponível` do `Local de Estoque` informado (mercadoria volta).
+- **Fiscal** — NF-e de devolução emitida pela SEFAZ, com a referência à venda original.
+- **Financeiro / Crédito ao cliente** — se o Tipo está configurado com `Devolução Crédito` ativo (em `37`), um **Crédito de Pessoa** é gerado, visível na sub-aba `Crédito - Gerado` do movimento e na ficha do cliente. O crédito pode ser usado para abater compras futuras.
+
+---
+
+## 🛍️ Variação — duas etapas para devolução de cupom (loja de balcão)
+
+Em lojas com volume alto de devoluções (supermercados, varejo), há um padrão otimizado: o atendente cria um **`PEDIDO DE DEVOLUÇÃO`** rapidamente durante o atendimento; no fechamento do dia, todos os pedidos viram uma **`NF-e Devolução`** consolidada.
+
+A configuração-chave é o flag `Referenciar Mov. Próprio` no Tipo `NF-e Devolução` em `37` — **desmarcado**, faz a NF-e final herdar a referência ao **cupom fiscal de origem** (não ao pedido intermediário).
+
+**Operação:**
+
+1. **Durante o dia**, o atendente: `F1` → `203` → `Novo` → Tipo `PEDIDO DE DEVOLUÇÃO` → aponta o cupom fiscal (chave NFC-e) → confere itens → finaliza. Cliente sai com comprovante; sem NF-e ainda.
+2. **No fechamento**, o operador localiza todos os pedidos do dia (filtro por Tipo + período).
+3. Em cada pedido, aplica `F7 Mudar` → vira `NF-e Devolução`. Como `Referenciar Mov. Próprio` está desmarcado no Tipo destino, a NF-e referencia o cupom original (não o pedido).
+4. Estoque volta e (se configurado) Crédito de Pessoa é gerado.
+
+Detalhes em [Outros Movimentos — devolução de cupom](../Movimentos/outros_movimentos.md#exemplos-pr%C3%A1ticos).
+
+> ⚠️ **Acesso de suporte necessário:** os Tipos `PEDIDO DE DEVOLUÇÃO` e `NF-e Devolução` vêm do `Cadastro de Tipos de Movimento` (`37`), que requer permissão de acesso de suporte. Entre em contato com o suporte Hetosoft antes de criar ou alterar esses Tipos.
+
+---
+
+## ⚠️ Quando dá errado
+
+| Mensagem | Etapa | Onde resolver |
+|---|---|---|
+| `Não Permitido, Obrigatório Referenciar Nota! (Devolução)` | 4 | Falta a referência à venda original. Volte ao passo 3. |
+| `Não Permitido, Obrigatório Referenciar Nota da Mesma Empresa! (Devolução)` | 3 | A nota referenciada é de outra empresa. Use a venda da mesma empresa do movimento atual. |
+| `Movimento sem item!` | 4 | Adicione ao menos um item na sub-aba `Itens`. |
+| `CFOP não é de entrada!` em devolução de venda | 4 | Devolução de venda fiscalmente é uma entrada (mercadoria volta). Verifique se o Tipo está com CFOPs `1202`/`2202`/`1410`/`2410` ou equivalentes. |
+| NF-e de devolução `Rejeitada` pela SEFAZ | 4 | Leia o motivo no `Protocolo Fiscal`. Causas comuns: referência à nota original ausente/incorreta, CFOP incompatível, item da devolução não está na nota original. |
+
+Lista completa em [Índice de mensagens](../indice_mensagens.md).
+
+---
+
+## 💡 Exemplos práticos
+
+### Devolução pontual de uma venda com NF-e identificada
+
+Cliente com NF-e na mão devolve um item. `203` → `Novo` → Tipo `DEVOLUÇÃO DE VENDA` → Pessoa = cliente → Itens = produto devolvido → Referencia a NF-e original → `F6`. Estoque volta, NF-e de devolução emitida, crédito gerado (se configurado).
+
+### Devolução parcial
+
+Cliente devolve só 2 de 5 unidades vendidas. Mesmo fluxo, mas no item informa apenas a quantidade devolvida (`2`). A NF-e de devolução referencia a venda original mas com quantidade parcial.
+
+### Devolução de cupom NFC-e em supermercado
+
+Use o padrão de **duas etapas** descrito acima. Atendente cria `PEDIDO DE DEVOLUÇÃO` durante o atendimento; no fechamento, todos os pedidos viram `NF-e Devolução` consolidada via `F7 Mudar`.
+
+---
+
+## 🔗 Para aprofundar
+
+| Tela / Doc | Quando consultar |
+|---|---|
+| [Outros Movimentos](../Movimentos/outros_movimentos.md) (`203`) | Particularidades do modo Outros, exemplos completos de devolução de cupom. |
+| [Movimentos — referência](../Movimentos/documentacao_movimentos.md) | Ciclo de vida, validações, sub-aba `Crédito - Gerado`. |
+| [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) | Configuração `Devolução = Sim`, `Devolução Crédito`, `Referenciar Mov. Próprio`. |
+| [Tipos de Movimento — referência de configurações](../TiposDeMovimento/referencia_configuracoes_tipos_movimento.md) | Detalhe de cada flag mencionada acima. |
+| [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) | Auditoria. |
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 1.0
+**Público-alvo**: Retaguarda / Atendimento / Operação fiscal

--- a/Movimentacao/Trilhas/trilha_devolucao_venda.md
+++ b/Movimentacao/Trilhas/trilha_devolucao_venda.md
@@ -143,7 +143,7 @@ Use o padrão de **duas etapas** descrito acima. Atendente cria `PEDIDO DE DEVOL
 | [Movimentos — referência](../Movimentos/documentacao_movimentos.md) | Ciclo de vida, validações, sub-aba `Crédito - Gerado`. |
 | [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) | Configuração `Devolução = Sim`, `Devolução Crédito`, `Referenciar Mov. Próprio`. |
 | [Tipos de Movimento — referência de configurações](../TiposDeMovimento/referencia_configuracoes_tipos_movimento.md) | Detalhe de cada flag mencionada acima. |
-| [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) | Auditoria. |
+| [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) | Análise e totais de devoluções por período, vendedor, cliente. |
 
 ---
 

--- a/Movimentacao/Trilhas/trilha_entrada_nfe.md
+++ b/Movimentacao/Trilhas/trilha_entrada_nfe.md
@@ -1,0 +1,173 @@
+# 📄 Trilha — Entrada de NF-e completa - Sol.NET
+
+## 🎯 Visão Geral
+
+Trilha narrativa que cobre o ciclo completo de **uma entrada de mercadoria via NF-e**: desde a chegada do XML pela SEFAZ até o estoque na prateleira e o título de Pagar gerado.
+
+Esta trilha atravessa **três telas** e (opcionalmente) o aplicativo `Sol.NET Administrativo`:
+
+- [Manifestação do Destinatário](../../Fiscal/documentacao_manifestacao_destinatario.md) (`401`) — fecha a obrigação fiscal.
+- [Importar XML NF-e](../documentacao_importar_xml.md) (`204`) — converte o XML em movimento de entrada.
+- [Conferência de XML](../documentacao_conferencia_xml.md) — quando a empresa exige contagem física antes do lançamento.
+- [Movimentos de Compras](../Movimentos/movimentos_de_compras.md) (`201`) — onde o movimento aparece e é finalizado.
+
+> 💡 **Quando usar.** Toda vez que uma NF-e de fornecedor chega pela SEFAZ (caminho padrão). Para XMLs que vieram por fora (e-mail, pendrive), pule a Manifestação e vá direto à etapa 3.
+
+---
+
+## 🗺️ Fluxo completo
+
+```mermaid
+flowchart TD
+  S([SEFAZ libera XML]) --> M[1 - Manifestar<br/>Tela Manifestação 401]
+  M --> XML[2 - Lançar pelo botão NF-e<br/>Tela Importar XML 204]
+  XML --> C{Empresa exige<br/>conferência?}
+  C -->|Sim| Conf[3 - Conferir mercadoria<br/>App Sol.NET Administrativo]
+  Conf --> L[4 - Lançar NF-e<br/>Importar XML 204]
+  C -->|Não| L
+  L --> Mov[5 - Conferir e finalizar movimento<br/>Movimentos de Compras 201]
+  Mov --> E[(Estoque entra)]
+  Mov --> F[(Título de Pagar gerado)]
+```
+
+---
+
+## 1️⃣ Manifestar a NF-e — tela [Manifestação do Destinatário](../../Fiscal/documentacao_manifestacao_destinatario.md) (`401`)
+
+A SEFAZ exige manifestação antes de qualquer lançamento. O `Sol.NET_MonitorNFCe` baixa o XML automaticamente em ciclos de ~59 minutos e deixa disponível para manifestação aqui.
+
+**O que fazer:**
+
+1. Abra a pesquisa (`F1`) e digite `401`.
+2. Localize a NF-e no grid (filtros por loja, fornecedor, período ou chave de acesso).
+3. Com a linha selecionada, clique em `Confirmar(1)` (mercadoria recebida) ou `Ciência(4)` (registra conhecimento sem comprometer).
+4. A coluna `Evento` passa a refletir a manifestação enviada.
+
+**Resultado esperado:** evento de manifestação confirmado na SEFAZ. A NF-e está pronta para virar movimento.
+
+> 💡 Os dois pares de botões `NF-e`/`CT-e` à esquerda da tela são **descontinuados** — não usar. Para lançar a entrada, use o botão `NF-e` que fica **entre `Zerar NSU` e `Confirmar`**.
+
+---
+
+## 2️⃣ Abrir o XML no lançamento — tela [Importar XML NF-e](../documentacao_importar_xml.md) (`204`)
+
+**O que fazer:**
+
+1. Ainda na tela `Manifestação`, com a linha selecionada, clique no botão **`NF-e`** (entre `Zerar NSU` e `Confirmar`).
+2. O Sol.NET abre a tela `Importar XML NF-e` **em modo de inclusão**, com cabeçalho, fornecedor, itens, tributos e parcelas já preenchidos a partir do XML.
+3. Na aba `Itens`, confira que todos estão **vinculados** (descrição preenchida). Itens sem vínculo precisam ser resolvidos antes de lançar:
+   - **Duplo clique** sobre o item sem descrição.
+   - O `Cadastro de Produtos` (`32`) abre em modo pesquisa, com a descrição do fornecedor exibida no topo.
+   - Localize o produto correspondente no cadastro **ou** inclua um novo (os campos `Cód. Fornecedor`, `EAN Fornecedor` e `Descrição Fornecedor` já vêm preenchidos do XML).
+4. Na aba `Financeiro`, confira as parcelas trazidas do XML.
+
+**Resultado esperado:** XML com todos os itens vinculados. Status `Edição` ou `Finalizado` (pronto para lançar).
+
+> 💡 **Fornecedor novo.** Quando o emitente não está cadastrado, o campo `Fornecedor` na aba `Cabeçalho` fica em branco. Use o botão de cadastro à direita do campo — o `Cadastro de Pessoas` abre com CNPJ, razão e endereço já preenchidos.
+
+---
+
+## 3️⃣ Conferir a mercadoria (se a empresa exige) — app `Sol.NET Administrativo`
+
+Lojas com **tipo de conferência XML habilitado** no `Cadastro de Empresas` exigem contagem física antes do lançamento. A contagem é registrada no app **Sol.NET Administrativo** — não na tela `204`. A aba `Conferência` em `Importar XML` apenas **exibe** o resultado.
+
+**O que fazer:**
+
+1. No app `Sol.NET Administrativo`, abra a NF-e (mesma chave de acesso).
+2. Conferente passa item a item, confirmando ou registrando divergência.
+3. O resultado fica disponível na aba `Conferência` da tela `204` no portal.
+
+**Resultado esperado:** `Status Conferência` muda para `Finalizada Sem Divergência` ou `Finalizada Com Divergência`. Reflete no grid da tela `204` (a coluna `Conf.` muda de cor).
+
+> ℹ️ A reabertura de uma conferência já finalizada requer permissão específica (código `375`) e é feita no portal. Detalhes em [Conferência de XML](../documentacao_conferencia_xml.md).
+
+---
+
+## 4️⃣ Lançar a NF-e — tela [Importar XML NF-e](../documentacao_importar_xml.md) (`204`)
+
+Com o XML pronto (e a conferência feita, quando aplicável), gere o movimento de entrada.
+
+**Decida o botão pela situação:**
+
+| Botão | Quando usar |
+|---|---|
+| **`Lançar NF-e`** | Fluxo padrão: a mercadoria chegou exatamente como descrita na NF-e. |
+| **`Lançar Parcial`** | Só parte da mercadoria foi recebida. Marca/desmarca itens e ajusta quantidades antes da gravação. |
+| **`Lançar Próprio`** | NF-e emitida pela própria empresa (campo `Emissão` = `PROPRIA`). Caso de conciliação de saídas emitidas por fora. |
+
+**O que fazer:**
+
+1. Clique em `Lançar NF-e` (ou variante).
+2. O Sol.NET abre a tela `Movimentos de Compras` (`201`) já preenchida com cabeçalho, itens, tributos e financeiro do XML.
+3. Confira o `Tipo de Movimento` proposto (se houver mais de um Tipo aplicável, o usuário escolhe).
+4. Grave o movimento.
+
+**Resultado esperado:** o XML passa para status `Importado` e ganha vínculo com o `ID_MOVIMENTO` criado. O movimento aparece em `201` para ser finalizado.
+
+---
+
+## 5️⃣ Finalizar o movimento — tela [Movimentos de Compras](../Movimentos/movimentos_de_compras.md) (`201`)
+
+**O que fazer:**
+
+1. Confira o `Tipo de Movimento`, `Local de Estoque` de entrada, `Pessoa` (fornecedor), `Datas` (Emissão = da NF, E/S = recebimento físico), `Condição de Pagamento`.
+2. Na sub-aba `Itens`, confira preços, quantidades e custos. Se o Tipo tiver `Atualizar Custo Automático` marcado, o custo informado **propaga** para o cadastro do produto ao gravar.
+3. Na sub-aba `Financeiro → Parcelas`, confira/edite as parcelas geradas a partir do XML ou da Condição de Pagamento.
+4. Pressione `F6` para **Finalizar** o movimento.
+
+**Resultado esperado (após finalizar):**
+
+- **Estoque** — soma na camada `Físico` e `Disponível` do `Local de Estoque` informado.
+- **Financeiro** — título(s) de Pagar gerado(s) com vencimento da Condição de Pagamento, visíveis em [Pagar e Receber](../../Financeiro/documentacao_pagar_e_receber.md) (`301`).
+- **Fiscal** — a NF-e do fornecedor fica vinculada ao movimento e as colunas `M-` da tela `401` mostram o vínculo.
+- **Custo** — se o Tipo está configurado para atualizar custo, o cadastro do produto recebe o novo custo.
+
+---
+
+## ⚠️ Quando dá errado
+
+| Mensagem | Etapa | Onde resolver |
+|---|---|---|
+| `Chave de Acesso já Cadastrada!` | 2 | XML já foi carregado antes. Localize o registro existente no grid da tela `204` em vez de carregar de novo. |
+| `( fornecedor ) NÃO É SUA EMPRESA!` | 2 | CNPJ do destinatário no XML não bate com nenhuma loja cadastrada. Verifique se a NF-e foi emitida para o CNPJ correto. |
+| `Não Existe Nenhum Item com Vinculo!` | 2 | Há itens sem vínculo no XML. Volte na aba `Itens` e vincule cada item. |
+| `Não Permitido, Tipo Serviço!` ao vincular | 2 | Produto selecionado é do tipo `Serviço`. Itens de NF-e de mercadoria não casam com produtos de serviço — selecione outro produto. |
+| `CFOP não é de entrada!` | 5 | Tipo de Movimento usado tem CFOP fora da faixa de entrada (`1xxx`/`2xxx`/`3xxx`). Use outro Tipo, ou ajuste a Natureza de Operação. |
+| `Caixa Aberto. Fechamento Nº: ( ... )` | 5 | Tipo exige caixa aberto e o caixa do usuário está fechado. Abra o caixa em [Caixa Geral — operação](../../Financeiro/documentacao_caixa_geral_op.md) (`302`). |
+
+Lista completa em [Índice de mensagens](../indice_mensagens.md).
+
+---
+
+## 💡 Exemplos práticos
+
+### Fornecedor recorrente, todos os itens já vinculados
+
+Cenário mais comum. Manifesta → abre pelo botão `NF-e` → lança → finaliza. O ciclo inteiro leva poucos minutos porque o vínculo de cada item já foi gravado em compras anteriores.
+
+### Primeira compra de um fornecedor novo
+
+O fornecedor não existe no cadastro e nenhum item está vinculado. Cadastre o fornecedor pelo botão à direita do campo `Fornecedor` (o `Cadastro de Pessoas` abre pré-preenchido). Em seguida, vincule item a item por duplo clique. A partir da segunda compra desse fornecedor, vira fluxo recorrente.
+
+### Recebimento parcial
+
+A NF-e tem 10 itens, só 7 chegaram. Vincule todos os 10 e, ao lançar, use `Lançar Parcial` em vez de `Lançar NF-e`. Marque na aba `Itens` (coluna `Sel.`) só os 7 itens recebidos. O XML permanece para complementação futura.
+
+---
+
+## 🔗 Para aprofundar
+
+| Tela / Doc | Quando consultar |
+|---|---|
+| [Manifestação do Destinatário](../../Fiscal/documentacao_manifestacao_destinatario.md) (`401`) | Filtros, eventos da manifestação, prazo legal, NSU. |
+| [Importar XML NF-e](../documentacao_importar_xml.md) (`204`) | Detalhes de cada sub-aba, regras de vínculo, bloqueios. |
+| [Conferência de XML](../documentacao_conferencia_xml.md) | Habilitação por loja, estados da conferência, permissão de reabertura. |
+| [Movimentos de Compras](../Movimentos/movimentos_de_compras.md) (`201`) | Particularidades do modo Compras. |
+| [Movimentos — referência](../Movimentos/documentacao_movimentos.md) | Comportamento comum das três telas (`201/202/203`), ciclo de vida, validações. |
+| [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) | Por que o Tipo escolhido se comporta assim. |
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 1.0
+**Público-alvo**: Equipe de recebimento / Retaguarda fiscal

--- a/Movimentacao/Trilhas/trilha_venda_completa.md
+++ b/Movimentacao/Trilhas/trilha_venda_completa.md
@@ -168,7 +168,7 @@ Cliente pede uma cotação. Lance um Tipo `ORÇAMENTO` em `202` — não baixa e
 | [Tabela de Preço](../documentacao_tabela_de_preco.md) (`27`) | Origem do preço aplicado a cada item. |
 | [Pagar e Receber](../../Financeiro/documentacao_pagar_e_receber.md) (`301`) | Onde os títulos gerados ficam disponíveis. |
 | [Quitação](../../Financeiro/documentacao_quitacao.md) (`303`) | Quitação em lote / por agrupamento. |
-| [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) | Auditoria do que aconteceu com cada movimento. |
+| [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) | Análise e totais de vendas — por dia, vendedor, portador, condição, tabela; cálculo de comissões. |
 
 ---
 

--- a/Movimentacao/Trilhas/trilha_venda_completa.md
+++ b/Movimentacao/Trilhas/trilha_venda_completa.md
@@ -1,0 +1,177 @@
+# 📄 Trilha — Venda completa - Sol.NET
+
+## 🎯 Visão Geral
+
+Trilha narrativa que cobre o ciclo completo de **uma venda na retaguarda**: do orçamento (quando há) até a baixa do título financeiro. Atravessa:
+
+- [Movimentos de Vendas](../Movimentos/movimentos_de_vendas.md) (`202`) — onde a venda é lançada, mudada, emitida.
+- Emissão fiscal — NF-e/NFC-e/NFS-e disparada pela própria tela `202`.
+- [Quitação](../../Financeiro/documentacao_quitacao.md) (`303`) ou [Pagar e Receber](../../Financeiro/documentacao_pagar_e_receber.md) (`301`) — quitação dos títulos gerados.
+
+> ℹ️ **PDV é separado.** Vendas em frente de caixa (cupom NFC-e, comanda) acontecem na aplicação **PDV**, não nesta tela. A tela `202` é para vendas operadas pela retaguarda (balcão atendido por vendedor, orçamento → pedido → faturamento, OS com faturamento). Movimentos do PDV aparecem aqui apenas para consulta/edição complementar.
+
+---
+
+## 🗺️ Fluxo completo
+
+```mermaid
+flowchart TD
+  V[1 - Lançar venda<br/>Movimentos de Vendas 202] --> Tipo{Há orçamento<br/>ou pedido?}
+  Tipo -->|Sim| Ciclo[2 - Mudar entre Tipos<br/>F7 — Orçamento → Pedido → Venda]
+  Tipo -->|Não| Fin[3 - Finalizar<br/>F6]
+  Ciclo --> Fin
+  Fin --> E[(Estoque sai)]
+  Fin --> F[(Título a Receber gerado)]
+  Fin --> Em[4 - Emitir documento fiscal<br/>F10 — NF-e/NFC-e/NFS-e]
+  Em --> Q[5 - Quitar título<br/>Quitação 303 ou Pagar e Receber 301]
+  Q --> Pago[(Título quitado)]
+```
+
+---
+
+## 1️⃣ Lançar a venda — tela [Movimentos de Vendas](../Movimentos/movimentos_de_vendas.md) (`202`)
+
+**O que fazer:**
+
+1. Abra a pesquisa (`F1`) e digite `202`.
+2. Clique em **Novo**.
+3. Na sub-aba `Cabeçalho`:
+   - Selecione o `Tipo de Movimento` (`VENDA BALCÃO`, `ORÇAMENTO`, `PEDIDO`, etc.).
+   - Preencha `Pessoa` (cliente — pode ser consumidor final genérico).
+   - Ajuste `Condição de Pagamento`, `Portador`, `Vendedor`, `Local de Estoque`, `Tabela de Preço`.
+4. Vá para a sub-aba `Itens` e adicione cada produto: código/EAN, quantidade, preço (vem da Tabela), desconto/acréscimo individual.
+5. Na sub-aba `Descontos/Outras Despesas`, lance frete, desconto no total ou outras despesas conforme acordado.
+6. Na sub-aba `Financeiro → Parcelas`, confira as parcelas geradas a partir da Condição de Pagamento.
+
+**Resultado esperado:** movimento gravado em estado aberto (`LANÇADO`), ainda sem efeito definitivo no estoque/financeiro.
+
+---
+
+## 2️⃣ Ciclo Orçamento → Pedido → Venda (quando aplicável) — `F7` Mudar
+
+Aplica-se quando o cliente passou primeiro por uma cotação ou pedido. A operação `Mudar` (`F7`) **converte o Movimento de um Tipo para outro** — o comportamento é decidido pelo cadastro do Tipo de destino:
+
+- **Transformar** — o mesmo Movimento muda de Tipo (identificador interno preservado). Não exige permissão de estorno. Histórico fica em uma única linha que progride.
+- **Duplicar** — um novo Movimento é criado; o original muda para `VINCULADO` e fica congelado. Forma uma pilha auditável visível na sub-aba `Vínculos`.
+
+A escolha entre Transformar e Duplicar é definida no cadastro do Tipo de destino, não pelo operador.
+
+**O que fazer:**
+
+1. Localize o movimento no grid (sub-aba `Movimentos`).
+2. Pressione `F7` ou clique em `Mudar`.
+3. O sistema oferece o(s) Tipo(s) de destino configurado(s) na aba `Mudar` do Tipo atual.
+4. Confirme — o movimento avança no ciclo. Quando `PEDIDO` é o destino, o estoque é baixado e o financeiro gerado neste momento; quando `NFC-e` ou `NF-e` é o destino, a quitação dispara e a emissão fiscal inicia.
+
+**Resultado esperado:** ciclo avançou para a próxima etapa. Cada etapa tem efeito específico conforme a configuração do Tipo.
+
+> 💡 **Exemplo do fluxo padrão de loja** (todos no modo `Transformar`):
+> ```
+> ORÇAMENTO ──F7──▶ PEDIDO ──F7──▶ NFC-E CUPOM FISCAL
+>   (sem estoque)     (estoque baixa,    (quita e emite)
+>                      financeiro abre)
+> ```
+
+---
+
+## 3️⃣ Finalizar — `F6`
+
+Para vendas diretas (sem ciclo orçamento/pedido), o passo é direto: lançar → finalizar.
+
+**O que fazer:**
+
+1. Com o movimento ainda em edição (ou já gravado), pressione `F6` ou clique em `Finalizar`.
+2. O sistema executa validações cruzadas: itens com vínculo, totalizações coerentes, caixa aberto (se o Tipo exige), série fiscal disponível, CFOPs compatíveis.
+3. Confirmadas as validações, o Movimento passa para `FINALIZADO`.
+
+**Resultado esperado:**
+
+- **Estoque** — subtrai das camadas configuradas na Transação de Estoque do Tipo (`Físico`, `Disponível`).
+- **Financeiro** — título(s) a Receber gerado(s), visíveis em [Pagar e Receber](../../Financeiro/documentacao_pagar_e_receber.md) (`301`).
+- **Fiscal** — se o Tipo não dispara emissão automática, ela acontece no passo seguinte.
+
+---
+
+## 4️⃣ Emitir documento fiscal — `F10`
+
+Para Tipos que emitem NF-e/NFC-e/NFS-e.
+
+**O que fazer:**
+
+1. Com o movimento finalizado selecionado, pressione `F10` ou clique em `NF-e`.
+2. O Sol.NET gera o XML, assina, envia à SEFAZ e aguarda retorno.
+3. O protocolo (autorizada, rejeitada, denegada) aparece na sub-aba `Movimentos → Protocolo Fiscal`.
+
+**Resultado esperado:** documento autorizado e com `Chave de Acesso` atribuída. DANFE pode ser impressa (`F9`).
+
+**Se rejeitada:** leia a mensagem da SEFAZ no `Protocolo Fiscal`, corrija o problema (CFOP, NCM, IE do destinatário etc.) e retransmita com `F10` novamente.
+
+> 💡 Tipos como `NFC-E CUPOM FISCAL` disparam a emissão automaticamente no `Finalizar` ou no `Mudar` final do ciclo — o passo manual de `F10` não é necessário nesses casos.
+
+---
+
+## 5️⃣ Quitar o título — tela [Quitação](../../Financeiro/documentacao_quitacao.md) (`303`) ou direto pelo movimento (`F8`)
+
+**O que fazer (pelo movimento):**
+
+1. Selecione o movimento em `202` na sub-aba `Movimentos`.
+2. Pressione `F8` ou clique em `Quitar`. Variantes: `Quitar Múltiplo`, `Quitar Contas PR`, `Quitar/Imprimir Só Portador`.
+3. Confirme valores, portador e data da quitação.
+
+**Ou (pela tela específica):**
+
+1. Abra `Quitação` (`303`) para quitação em lote.
+2. Localize o(s) título(s) do cliente e quite por seleção.
+
+**Resultado esperado:** título(s) com status `QUITADO`. Saldo do cliente atualizado em [Pagar e Receber](../../Financeiro/documentacao_pagar_e_receber.md) (`301`).
+
+---
+
+## ⚠️ Quando dá errado
+
+| Mensagem | Etapa | Onde resolver |
+|---|---|---|
+| `Movimento sem item!` | 3 | Adicione ao menos um item na sub-aba `Itens` antes de finalizar. |
+| `CFOP não é de saída!` | 3 | Tipo de Movimento com CFOP fora da faixa de saída (`5xxx`/`6xxx`/`7xxx`). Use outro Tipo ou ajuste a Natureza de Operação. |
+| `Caixa Aberto. Fechamento Nº: ( ... )` | 3 | Tipo exige caixa aberto. Abra o caixa em [Caixa Geral — operação](../../Financeiro/documentacao_caixa_geral_op.md) (`302`). |
+| `Atualizar Custo Automático, Somente para Compras/Outros!` | 3 | Tipo de saída está configurado com `Atualizar Custo` ativo — vendas não atualizam custo. Ajustar no cadastro do Tipo (`37`). |
+| `Empresa Não Permitida Para esse Tipo Movimento!` | 1 ou 3 | Tipo restrito a outra empresa. Selecione outro Tipo ou ajuste a configuração de Empresas no Tipo. |
+| NF-e `Rejeitada` pela SEFAZ | 4 | Leia o motivo no `Protocolo Fiscal`. Corrija o dado apontado e retransmita com `F10`. |
+
+Lista completa em [Índice de mensagens](../indice_mensagens.md).
+
+---
+
+## 💡 Exemplos práticos
+
+### Venda balcão à vista
+
+Cliente chega, compra, paga na hora. `202` → `Novo` → Tipo `VENDA BALCÃO` → Itens → `F6` (Finalizar). A quitação à vista acontece automaticamente porque a Condição de Pagamento é `À VISTA` e o Portador é `Caixa`. Cupom impresso conforme Relatório do Tipo.
+
+### Orçamento que vira pedido e depois venda
+
+Cliente pede uma cotação. Lance um Tipo `ORÇAMENTO` em `202` — não baixa estoque, não gera financeiro. Cliente aprova: `F7` para `PEDIDO` (estoque baixa, financeiro abre). Faturar: `F7` novamente para `NFC-E CUPOM FISCAL` (dispara quitação e emissão).
+
+### Venda a prazo com 3 parcelas
+
+`202` → `Novo` → Tipo `VENDA A PRAZO` → Condição `30/60/90`. Após `F6`, três títulos com vencimentos escalonados aparecem em `Pagar e Receber` (`301`). A quitação acontece à medida que cada parcela vence (vai em `303` ou direto pelo título em `301`).
+
+---
+
+## 🔗 Para aprofundar
+
+| Tela / Doc | Quando consultar |
+|---|---|
+| [Movimentos de Vendas](../Movimentos/movimentos_de_vendas.md) (`202`) | Particularidades do modo Vendas. |
+| [Movimentos — referência](../Movimentos/documentacao_movimentos.md) | Ciclo de vida (`Mudar`, `Quitar`, `Imprimir`, `NF-e`, `Estornar`), sub-abas, validações. |
+| [Tipos de Movimento](../TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) | Como configurar o ciclo Orçamento → Pedido → NF-e/NFC-e. |
+| [Tabela de Preço](../documentacao_tabela_de_preco.md) (`27`) | Origem do preço aplicado a cada item. |
+| [Pagar e Receber](../../Financeiro/documentacao_pagar_e_receber.md) (`301`) | Onde os títulos gerados ficam disponíveis. |
+| [Quitação](../../Financeiro/documentacao_quitacao.md) (`303`) | Quitação em lote / por agrupamento. |
+| [Histórico de Movimentações](../documentacao_historico_de_movimentacoes.md) (`205`) | Auditoria do que aconteceu com cada movimento. |
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 1.0
+**Público-alvo**: Vendedores de retaguarda / Operação comercial

--- a/Movimentacao/indice_mensagens.md
+++ b/Movimentacao/indice_mensagens.md
@@ -1,0 +1,246 @@
+# 📄 Índice unificado de mensagens - Sol.NET
+
+## 🎯 Visão Geral
+
+Índice consolidado das **mensagens de validação** que aparecem nas telas operacionais de Movimentação e nas telas relacionadas (Importar XML, Tipos de Movimento, Manifestação Fiscal). Use esta página quando uma mensagem aparecer e você não souber por onde começar a resolver.
+
+> 💡 **Esta página é índice, não fonte primária.** A coluna `Detalhes` aponta para a FAQ ou documentação onde a mensagem é explicada em profundidade. Quando uma mensagem nova for adicionada a uma FAQ específica, adicione também uma linha aqui — só assim o índice continua útil.
+
+**Cobertura desta primeira rodada:** mensagens das telas `201/202/203` (Movimentos), `37` (Tipos de Movimento), `204` (Importar XML) e mensagens relacionadas à Manifestação do Destinatário (`401`). Mensagens dos demais módulos (RH, Self Checkout, iFood, API Externa) entrarão em rodadas posteriores.
+
+---
+
+## 📑 Como ler a tabela
+
+- **Mensagem** — texto exato (ou parte significativa) que aparece em popup ou no protocolo.
+- **Onde aparece** — tela e momento (gravar, finalizar, vincular item etc.).
+- **Causa provável** — o motivo mais comum.
+- **Detalhes** — link para a FAQ/documentação onde o problema é explicado e resolvido.
+
+---
+
+## 🧾 Movimentos (`201/202/203`) — Cabeçalho, Tipo, Pessoa
+
+| Mensagem | Onde aparece | Causa provável | Detalhes |
+|---|---|---|---|
+| `Defina um Tipo de Movimento!` | Movimentos — ao gravar | Cabeçalho sem Tipo selecionado. | [FAQ — Movimentos](Movimentos/faq.md#cabe%C3%A7alho--tipo-pessoa-empresa) |
+| `Empresa Não Permitida Para esse Tipo Movimento!` | Movimentos — ao gravar | Empresa não autorizada no Tipo. | [FAQ — Movimentos](Movimentos/faq.md#cabe%C3%A7alho--tipo-pessoa-empresa) |
+| `Pessoa do Movimento Diferente da Pessoa da Chamada!` | Movimentos — ao gravar | Chamada vinculada é de outra pessoa. | [FAQ — Movimentos](Movimentos/faq.md#cabe%C3%A7alho--tipo-pessoa-empresa) |
+| `Chamada Obrigatório!` | Movimentos — ao finalizar | Tipo exige Chamada amarrada. | [FAQ — Movimentos](Movimentos/faq.md#devolu%C3%A7%C3%A3o-e-v%C3%ADnculos) |
+| `OS Obrigatório!` / `Empresa da 'OS' Diferente da 'OS-Requisição'!` / `Não Permitido, OS não Está em Aberto!` | Movimentos — ao finalizar | Validações de Ordem de Serviço vinculada. | [FAQ — Movimentos](Movimentos/faq.md#devolu%C3%A7%C3%A3o-e-v%C3%ADnculos) |
+
+---
+
+## 📦 Movimentos — Itens
+
+| Mensagem | Onde aparece | Causa provável | Detalhes |
+|---|---|---|---|
+| `Movimento sem item!` | Movimentos — ao gravar/finalizar | Sub-aba `Itens` vazia. | [FAQ — Movimentos](Movimentos/faq.md#itens) |
+| `Deletar Produto Linkado Só Individualmente!` | Movimentos — ao excluir itens em lote | Item com vínculo (bundle, fórmula). | [FAQ — Movimentos](Movimentos/faq.md#itens) |
+| `Atualização de custo bloqueada para este tipo de movimento.` | Movimentos — ao recalcular custo | Tipo de venda (não permite atualizar custo). | [FAQ — Movimentos](Movimentos/faq.md#itens) |
+| `Erro ao Atualizar Custo!` / `Erro ao Recalcular Preços!` | Movimentos — ao recalcular | Saldo inconsistente, custo zero, divisão por zero. | [FAQ — Movimentos](Movimentos/faq.md#itens) |
+| `Alteraram o 'Custo' Antes de Voçê, Consulte a Nota de Novo!` / `Alteraram o 'Preço' …` | Movimentos — ao gravar edição | Outro usuário alterou no mesmo movimento. | [FAQ — Movimentos](Movimentos/faq.md#itens) |
+
+---
+
+## 🏛️ Movimentos — Fiscal (CFOP, Chave de Acesso)
+
+| Mensagem | Onde aparece | Causa provável | Detalhes |
+|---|---|---|---|
+| `CFOP não é de entrada!` | `201` — ao finalizar | CFOP fora da faixa `1xxx/2xxx/3xxx`. | [FAQ — Movimentos](Movimentos/faq.md#fiscal--cfop-chave-de-acesso-cidade) |
+| `CFOP não é de saída!` | `202` — ao finalizar | CFOP fora da faixa `5xxx/6xxx/7xxx`. | [FAQ — Movimentos](Movimentos/faq.md#fiscal--cfop-chave-de-acesso-cidade) |
+| `CFOP não é dentro do estado!` / `CFOP não é dentro do estado! (NFC-e)` | Movimentos — ao finalizar | NFC-e ou operação interna com CFOP interestadual. | [FAQ — Movimentos](Movimentos/faq.md#fiscal--cfop-chave-de-acesso-cidade) |
+| `CFOP não é fora do estado!` | Movimentos — ao finalizar | Esperava interestadual; informou interno. | [FAQ — Movimentos](Movimentos/faq.md#fiscal--cfop-chave-de-acesso-cidade) |
+| `CFOP não é Exterior(Internacional)!` | Movimentos — ao finalizar | Importação/exportação com CFOP interno. | [FAQ — Movimentos](Movimentos/faq.md#fiscal--cfop-chave-de-acesso-cidade) |
+| `Chave de Acesso Incorreta!` | Movimentos — ao referenciar nota | Chave inválida (formato ou dígito verificador). | [FAQ — Movimentos](Movimentos/faq.md#fiscal--cfop-chave-de-acesso-cidade) |
+| `Chave de Acesso já Criada Edição Parcial!` | Movimentos — ao editar | Tentou editar campo travado em movimento com NF-e autorizada. | [FAQ — Movimentos](Movimentos/faq.md#fiscal--cfop-chave-de-acesso-cidade) |
+| `Cidade de Prestação sem Configuração de Tributação!` | Movimentos — ao finalizar NFS-e | Cidade do prestador sem configuração de tributação. | [FAQ — Movimentos](Movimentos/faq.md#fiscal--cfop-chave-de-acesso-cidade) |
+
+---
+
+## 💰 Movimentos — Caixa, Portador, Quitação
+
+| Mensagem | Onde aparece | Causa provável | Detalhes |
+|---|---|---|---|
+| `Caixa Aberto. Fechamento Nº: ( … )` / `Caixa Aberto. Turno Nº: ( … )` | Movimentos — ao finalizar | Caixa precisa estar aberto/fechado e está no estado oposto. | [FAQ — Movimentos](Movimentos/faq.md#caixa-quita%C3%A7%C3%A3o-e-portador) |
+| `Apenas Portador já impresso, podem ser limpo!` | Movimentos — ao limpar portador | Tentou limpar portador de título não impresso. | [FAQ — Movimentos](Movimentos/faq.md#caixa-quita%C3%A7%C3%A3o-e-portador) |
+| `Apenas títulos com status 'ABERTOS, CANCELADOS' podem ser limpo o portador!` | Movimentos — ao limpar portador | Título quitado/parcial. | [FAQ — Movimentos](Movimentos/faq.md#caixa-quita%C3%A7%C3%A3o-e-portador) |
+| `Entrada inválida!` / `Entrada menor que o permitido` / `Entrada igual ou maior que o valor!` | Movimentos — ao quitar | Valor de entrada fora dos limites. | [FAQ — Movimentos](Movimentos/faq.md#caixa-quita%C3%A7%C3%A3o-e-portador) |
+
+---
+
+## 🔄 Movimentos — Devolução
+
+| Mensagem | Onde aparece | Causa provável | Detalhes |
+|---|---|---|---|
+| `Não Permitido, Obrigatório Referenciar Nota! (Devolução)` | Movimentos — ao finalizar devolução | Tipo Devolução sem `Movimento Referenciado`. | [FAQ — Movimentos](Movimentos/faq.md#devolu%C3%A7%C3%A3o-e-v%C3%ADnculos) · [Trilha de devolução](Trilhas/trilha_devolucao_venda.md) |
+| `Não Permitido, Obrigatório Referenciar Nota da Mesma Empresa! (Devolução)` | Movimentos — ao finalizar devolução | Referência aponta para nota de outra empresa. | [FAQ — Movimentos](Movimentos/faq.md#devolu%C3%A7%C3%A3o-e-v%C3%ADnculos) · [Trilha de devolução](Trilhas/trilha_devolucao_venda.md) |
+
+---
+
+## 🛠️ Movimentos — Operação e auxiliares
+
+| Mensagem | Onde aparece | Causa provável | Detalhes |
+|---|---|---|---|
+| `Correção Manual permitido apenas em modo de Pesquisa` | Movimentos | Tentou Correção Manual com movimento aberto em edição. | [FAQ — Movimentos](Movimentos/faq.md#modo-de-opera%C3%A7%C3%A3o) |
+| `Essa função só pode ser utilizada em modo de Busca!` | Movimentos | Operação só vale sobre a lista, não sobre um movimento aberto. | [FAQ — Movimentos](Movimentos/faq.md#modo-de-opera%C3%A7%C3%A3o) |
+| `Escolha pelo menos Um(1) Movimento!` | Movimentos — operação em lote | Nada selecionado. | [FAQ — Movimentos](Movimentos/faq.md#modo-de-opera%C3%A7%C3%A3o) |
+| `Tipo de Movimento diferente do tipo escolhido em Ajuste de Estoque!` | `203` — ao lançar | Lançamento direto conflita com ajuste em andamento. | [FAQ — Movimentos](Movimentos/faq.md#tipo-de-movimento-divergente-em-opera%C3%A7%C3%B5es-disparadas) |
+
+### Erros genéricos (gravação, integridade, cálculo)
+
+| Mensagem | Detalhes |
+|---|---|
+| `Erro ao Agrupar Movimento!` | [FAQ — Movimentos](Movimentos/faq.md#erros-gen%C3%A9ricos) |
+| `Erro ao Cadastrar o Cliente!` | [FAQ — Movimentos](Movimentos/faq.md#erros-gen%C3%A9ricos) |
+| `Erro ao Calcular!` | [FAQ — Movimentos](Movimentos/faq.md#erros-gen%C3%A9ricos) |
+| `Erro ao Cancelar Financeiro!` | [FAQ — Movimentos](Movimentos/faq.md#erros-gen%C3%A9ricos) |
+| `Erro ao gerar parcelas!` / `Erro ao gerar parcelas com valor negativo!` | [FAQ — Movimentos](Movimentos/faq.md#erros-gen%C3%A9ricos) |
+| `Erro ao Excluir Crédito!` | [FAQ — Movimentos](Movimentos/faq.md#erros-gen%C3%A9ricos) |
+| `Erro ao Gravar no Banco de Dados os Itens!` | [FAQ — Movimentos](Movimentos/faq.md#erros-gen%C3%A9ricos) |
+
+---
+
+## 📥 Importar XML (`204`)
+
+### Carregamento
+
+| Mensagem | Causa provável | Detalhes |
+|---|---|---|
+| `Arquivo XML Inválido!` | Arquivo corrompido, modelo errado (NFC-e/CT-e/NFS-e/MDF-e), salvo como texto, alterado manualmente. | [FAQ — Importar XML](faq_importar_xml.md#-por-que-aparece-arquivo-xml-inv%C3%A1lido) |
+| `Chave de Acesso já Cadastrada!` | XML já carregado (por outro usuário, pela Manifestação ou em segundo plano). | [FAQ — Importar XML](faq_importar_xml.md#-aparece-chave-de-acesso-j%C3%A1-cadastrada-mas-eu-n%C3%A3o-importei-essa-nota-por-qu%C3%AA) |
+| `( razão social ) NÃO É SUA EMPRESA!` | CNPJ do destinatário no XML não bate com nenhuma loja cadastrada. | [FAQ — Importar XML](faq_importar_xml.md#--raz%C3%A3o-social--n%C3%83o-%C3%89-sua-empresa--o-que-isso-significa) |
+| `Pessoa não cadastrada!` ao vincular item | Fornecedor do XML não está no cadastro de pessoas. | [Documentação Importar XML](documentacao_importar_xml.md#erros-de-carregamento-comuns) |
+
+### Vínculo de itens
+
+| Mensagem | Causa provável | Detalhes |
+|---|---|---|
+| `Não Existe Nenhum Item com Vinculo!` | Lançamento bloqueado enquanto houver item sem vínculo. | [Documentação Importar XML](documentacao_importar_xml.md#coluna-conf-no-grid-de-itens) |
+| `Não Permitido, Tipo Serviço!` | Item vinculado a produto cadastrado como Serviço. | [FAQ — Importar XML](faq_importar_xml.md#-n%C3%A3o-permitido-tipo-servi%C3%A7o-ao-vincular-item--o-que-fazer) |
+| `Não Permitido, Produto configurado para desagregação!` | Produto marcado para desagregação tem fluxo próprio. | [FAQ — Importar XML](faq_importar_xml.md#-n%C3%A3o-permitido-produto-configurado-para-desagrega%C3%A7%C3%A3o--por-que-aparece) |
+| `Não Permitido, Vinculo de produto linkado!` | Configuração geral proíbe vincular produtos linkados. | [Documentação Importar XML](documentacao_importar_xml.md#regras-e-bloqueios-no-v%C3%ADnculo) |
+| `Produto Linkado Selecionado!` | Aviso (não bloqueio) — vinculou produto linkado em configuração que permite. | [Documentação Importar XML](documentacao_importar_xml.md#regras-e-bloqueios-no-v%C3%ADnculo) |
+
+### Lançamento
+
+| Mensagem | Causa provável | Detalhes |
+|---|---|---|
+| `Não Permitido! Somente Emissão PROPRIA.` | Usou `Lançar Próprio` em NF-e de terceiros. | [FAQ — Importar XML](faq_importar_xml.md#-tentei-lan%C3%A7ar-pr%C3%B3prio-e-apareceu-somente-emiss%C3%A3o-propria-o-que-fazer) |
+| `Movimentação Cancelada! Lançar NF-e Novamente.` | Movimento vinculado foi cancelado; vínculo é desfeito automaticamente. | [Documentação Importar XML](documentacao_importar_xml.md#lan%C3%A7ar-pr%C3%B3prio) |
+| `Movimentação Excluida! Lançar NF-e Novamente.` | Movimento vinculado foi excluído. | [FAQ — Importar XML](faq_importar_xml.md#-lancei-o-xml-mas-vi-que-o-movimento-foi-exclu%C3%ADdo-depois-o-v%C3%ADnculo-ainda-existe) |
+| `Diferença de Custo de X%` | Aviso (não bloqueio) — custo do XML difere do cadastrado acima do percentual configurado. | [FAQ — Importar XML](faq_importar_xml.md#-aparece-diferen%C3%A7a-de-custo-de-x-no-lan%C3%A7amento-devo-cancelar) |
+
+---
+
+## ⚙️ Tipos de Movimento (`37`) — validações ao salvar
+
+> ⚠️ **Acesso de suporte necessário:** alterações no `Cadastro de Tipos de Movimento` requerem permissão de acesso de suporte. Entre em contato com o suporte Hetosoft antes de realizar qualquer modificação nesta tela.
+
+### Identificação e Conta
+
+| Mensagem | Causa | Detalhes |
+|---|---|---|
+| `Esse tipo de conta só pode ser Analítica!` | Tipo Sintética com Complemento preenchido. | [FAQ — Tipos](TiposDeMovimento/faq.md#identifica%C3%A7%C3%A3o-e-conta-aba-dados-cadastrais) |
+| `Esse tipo de conta só pode ser Sintética!` | Tipo Analítica sem Complemento. | [FAQ — Tipos](TiposDeMovimento/faq.md#identifica%C3%A7%C3%A3o-e-conta-aba-dados-cadastrais) |
+
+### Fiscal
+
+| Mensagem | Causa | Detalhes |
+|---|---|---|
+| `Tipo Emissão Terceiro não permitido… ( … )!` | Tipo Emissão Terceiro com sequência incompatível. | [FAQ — Tipos](TiposDeMovimento/faq.md#fiscal-aba-cabe%C3%A7alho--fiscal) |
+| `Não Permitido, CFOP em Natureza de Op. Não é de entrada!` / `Não é de Saída!` | Comportamento × CFOP da Natureza incompatíveis. | [FAQ — Tipos](TiposDeMovimento/faq.md#fiscal-aba-cabe%C3%A7alho--fiscal) |
+| `Selecione ao menos uma série!` / `Selecione ao menos uma série padrão!` / `série padrão tem que está selecionada!` | Configuração de série fiscal incompleta. | [FAQ — Tipos](TiposDeMovimento/faq.md#fiscal-aba-cabe%C3%A7alho--fiscal) |
+| `Tipos de Séries (Fiscal/Não Fiscal) devem ser iguais Ao Tipo do Modelo de Documento!` | Série fiscal × Modelo não fiscal (ou vice-versa). | [FAQ — Tipos](TiposDeMovimento/faq.md#fiscal-aba-cabe%C3%A7alho--fiscal) |
+| `Série RPS e Série Lote é Obrigatório para NFS-e!` | Modelo NFS-e exige as duas séries adicionais. | [FAQ — Tipos](TiposDeMovimento/faq.md#fiscal-aba-cabe%C3%A7alho--fiscal) |
+| `Obrigatório marcar a Tag Consumo em Outras Operações para o Modelo de Documento selecionado.` | Cupom Fiscal exige flag `Consumo`. | [FAQ — Tipos](TiposDeMovimento/faq.md#fiscal-aba-cabe%C3%A7alho--fiscal) |
+
+### Estoque, Tabela de Preço, Custo
+
+| Mensagem | Causa | Detalhes |
+|---|---|---|
+| `Não Permitido, Obrigatório Local de Estoque!` / `Obrigatório Transação de Estoque!` | Tipo que movimenta estoque sem Local/Transação padrão. | [FAQ — Tipos](TiposDeMovimento/faq.md#estoque-aba-itens--estoque) |
+| `Não Permitido, '…' Sem Transação de Estoque!` | `Estatística de Estoque` ou `Baixar Quantidade na Promoção` sem Transação. | [FAQ — Tipos](TiposDeMovimento/faq.md#estoque-aba-itens--estoque) |
+| `Selecione 'Vender Sem Estoque'!` | Tipo com Transação sem definir Sim/Não. | [FAQ — Tipos](TiposDeMovimento/faq.md#estoque-aba-itens--estoque) |
+| `Não permitido, Selecione uma forma de buscar o preço! Selecione uma Tabela de Preço!` | Nenhuma Tabela com `OPCAO = 1` marcada. | [FAQ — Tipos](TiposDeMovimento/faq.md#tabela-de-pre%C3%A7o-aba-itens--tabela-de-pre%C3%A7o) |
+| `Não permitido, selecione uma Tabela de Preço Padrão!` | Tabelas marcadas, nenhuma é Padrão. | [FAQ — Tipos](TiposDeMovimento/faq.md#tabela-de-pre%C3%A7o-aba-itens--tabela-de-pre%C3%A7o) |
+| `Não permitido, '…Atualizar Custo Automático', Somente para Compras/Outros!` | Flag em Tipo de Vendas. | [FAQ — Tipos](TiposDeMovimento/faq.md#quantidade-e-custo-aba-itens--quantidade) |
+
+### Devolução / Crédito / Origem-Destino
+
+| Mensagem | Causa | Detalhes |
+|---|---|---|
+| `Não permitido, '…Devolução…' Em uma devolução!` / `…Não é devolução!` | Flags de devolução inconsistentes. | [FAQ — Tipos](TiposDeMovimento/faq.md#devolu%C3%A7%C3%A3o-e-cr%C3%A9dito-aba-outras-opera%C3%A7%C3%B5es--sistema) |
+| `Não permitido, Sem '…Devolução Crédito…'!` / `'…Devolução Crédito…' se não gerar Crédito!` | Combinação flags de devolução × crédito incoerente. | [FAQ — Tipos](TiposDeMovimento/faq.md#devolu%C3%A7%C3%A3o-e-cr%C3%A9dito-aba-outras-opera%C3%A7%C3%B5es--sistema) |
+| `Não permitido, 'Quitar Crédito Automaticamente' se não gerar Crédito!` / `se não for Tipo de Mov. 'PDV'!` | `Quitar Crédito Automaticamente` exige PDV + gerar crédito. | [FAQ — Tipos](TiposDeMovimento/faq.md#devolu%C3%A7%C3%A3o-e-cr%C3%A9dito-aba-outras-opera%C3%A7%C3%B5es--sistema) |
+| `Não permitido, 'Empresa' Destino do Movimento do Tipo Pessoa!` | Tipo Destino Empresa em configuração que espera Pessoa. | [FAQ — Tipos](TiposDeMovimento/faq.md#origem--destino-aba-cabe%C3%A7alho--origemdestino) |
+| `Não permitido, Preencher 'Empresa'!` / `Não Preenchido 'Empresa'!` | Incoerência entre `Tipo Empresa Destino` e empresa selecionada. | [FAQ — Tipos](TiposDeMovimento/faq.md#origem--destino-aba-cabe%C3%A7alho--origemdestino) |
+| `Não Permitido Credito pessoa para Tipo de Movimento com Destino à Empresas!` | Crédito pessoa ✕ destino Empresa. | [FAQ — Tipos](TiposDeMovimento/faq.md#origem--destino-aba-cabe%C3%A7alho--origemdestino) |
+
+### PDV / Funcionários / Memorizar / OS
+
+| Mensagem | Causa | Detalhes |
+|---|---|---|
+| `Não permitido, Não Consultar em Lancamento para Tipo de Mov. 'PDV'!` | Tipo PDV não pode ter `Não Consultar`. | [FAQ — Tipos](TiposDeMovimento/faq.md#pdv-e-comportamento-aba-outras-opera%C3%A7%C3%B5es--sistema) |
+| `Não Permitido, '…Memorizar Vendedor…' com a opção '…Vínculo com Usuário…'!` | Memorizar Vendedor ✕ Vínculo Usuário. | [FAQ — Tipos](TiposDeMovimento/faq.md#pdv-e-comportamento-aba-outras-opera%C3%A7%C3%B5es--sistema) |
+| `Não Permitido, '…Memorizar Vendedor…' com a opção 'Funcionário Padrão'!` | Memorizar Vendedor ✕ Funcionário Padrão. | [FAQ — Tipos](TiposDeMovimento/faq.md#pdv-e-comportamento-aba-outras-opera%C3%A7%C3%B5es--sistema) |
+| `Não Permitido, '…Permitir Tipo Mov…' com a opção '…Devolução Crédito…'!` | Incompatibilidade. | [FAQ — Tipos](TiposDeMovimento/faq.md#pdv-e-comportamento-aba-outras-opera%C3%A7%C3%B5es--sistema) |
+| `Não Permitido, '…Permitir Financeiro Aberto…' com a opção '…Devolução Crédito…'!` | Incompatibilidade. | [FAQ — Tipos](TiposDeMovimento/faq.md#pdv-e-comportamento-aba-outras-opera%C3%A7%C3%B5es--sistema) |
+| `Não Permitido, '…Movimento Parcial…' com a opção 'Venda Parcial'!` | Incompatibilidade. | [FAQ — Tipos](TiposDeMovimento/faq.md#pdv-e-comportamento-aba-outras-opera%C3%A7%C3%B5es--sistema) |
+| `Não Permitido!, A Opção 'SEPARAR ITENS DO MOVIMENTO (Global)' Esta Ativada em Configuração Geral.` | Configuração global da empresa bloqueia. | [FAQ — Tipos](TiposDeMovimento/faq.md#pdv-e-comportamento-aba-outras-opera%C3%A7%C3%B5es--sistema) |
+| `Não Permitido!, A Opção 'Promoção com Atualização em Grupo (MAIOR= ou A CADA)' Esta Ativada em Configuração Geral.` | Configuração global. | [FAQ — Tipos](TiposDeMovimento/faq.md#pdv-e-comportamento-aba-outras-opera%C3%A7%C3%B5es--sistema) |
+| `Não permitido! '…OS…' e '…OS Requisição…' ao mesmo tempo.` | Tipo não pode ser OS e OS Requisição simultaneamente. | [FAQ — Tipos](TiposDeMovimento/faq.md#os--os-requisi%C3%A7%C3%A3o-aba-outras-opera%C3%A7%C3%B5es--sistema) |
+
+### Financeiro / Funcionário
+
+| Mensagem | Causa | Detalhes |
+|---|---|---|
+| `Plano de Contas e Centro de Custo Obrigatório para Tipo de Movimento com Financeiro!` | `Gerar Lançamento` ativo sem Plano/Centro padrão. | [FAQ — Tipos](TiposDeMovimento/faq.md#financeiro-aba-financeiro--financeiro-1) |
+| `Não permitido, 'Não Estornar Financeiro', Somente para Compras/Outros!` | Flag em Tipo de Saída (só vale para Entrada/Outros). | [FAQ — Tipos](TiposDeMovimento/faq.md#financeiro-aba-financeiro--financeiro-1) |
+| `…Só permitido para Funcionário!` | Configuração só faz sentido com funcionário. | [FAQ — Tipos](TiposDeMovimento/faq.md#funcion%C3%A1rio-e-outros) |
+| `Obrigatório Editar 'Chave Protocolo'!` | Configuração de protocolo exige edição manual. | [FAQ — Tipos](TiposDeMovimento/faq.md#funcion%C3%A1rio-e-outros) |
+
+---
+
+## 📨 Ajuste de Estoque (`79`) e telas auxiliares
+
+| Mensagem | Onde aparece | Causa | Detalhes |
+|---|---|---|---|
+| `Ajuste de Estoque sem Produtos!` | `79` — ao criar ajustes | Grid vazia. | [Ajuste de Estoque](documentacao_ajuste_de_estoque.md#valida%C3%A7%C3%B5es-autom%C3%A1ticas) |
+| `Não Permitido! Só Status Aberto.` | `79` — ao editar | Tentou editar ajuste já processado. | [Ajuste de Estoque](documentacao_ajuste_de_estoque.md#valida%C3%A7%C3%B5es-autom%C3%A1ticas) · [Trilha de ajuste](Trilhas/trilha_ajuste_estoque_auditoria.md) |
+| `Produto Configurado para 'Não Movimentar Estoque'!` | `79` — ao adicionar produto | Produto marcado para não movimentar no cadastro. | [Ajuste de Estoque](documentacao_ajuste_de_estoque.md#valida%C3%A7%C3%B5es-autom%C3%A1ticas) |
+| `Não Permitido, Quantidade Máxima Excedida (999.999,99)!` | `79` — contagem | Valor acima do limite. | [Ajuste de Estoque](documentacao_ajuste_de_estoque.md#valida%C3%A7%C3%B5es-autom%C3%A1ticas) |
+| `Só com Status 'ABERTO'` | `79` — ao excluir | Ajuste processado é imutável. | [Ajuste de Estoque](documentacao_ajuste_de_estoque.md#ao-excluir-um-ajuste) |
+| `Não permitido, Existe Movimento(s) Vinculado!` | `79` — ao excluir | Há movimentos gerados a partir do ajuste. | [Ajuste de Estoque](documentacao_ajuste_de_estoque.md#ao-excluir-um-ajuste) |
+
+---
+
+## 🏛️ Manifestação do Destinatário (`401`) e NF-e SEFAZ
+
+Mensagens vindas da SEFAZ (rejeições) aparecem no protocolo da NF-e (sub-aba `Protocolo Fiscal` em Movimentos) ou no log da Manifestação. Causas mais frequentes em ambiente real:
+
+| Tipo de rejeição | Causa típica | Onde resolver |
+|---|---|---|
+| Chave de Acesso inválida | Chave malformada ou já cancelada/inutilizada na SEFAZ. | Conferir DANFE/XML; pedir reemissão. |
+| Inscrição Estadual do destinatário inválida | IE do cadastro de Pessoa errada ou desabilitada. | Atualizar IE no `Cadastro de Pessoas`. |
+| CFOP inconsistente com a operação | CFOP no movimento não combina com sentido da operação (entrada/saída/interno/interestadual). | Ajustar [Natureza de Operação](../Fiscal/documentacao_natureza_operacao.md) ou Tipo de Movimento. |
+| NCM inválido / Tributação inconsistente | Produto sem NCM, ou NCM/CST/CSOSN não bate com cadastro fiscal. | [Cadastro de NCM](../Fiscal/documentacao_ncm.md) e cadastro do Produto. |
+| Documento referenciado obrigatório (devolução) | Falta NF original referenciada na devolução. | Referenciar a NF original no Cabeçalho. Ver [Trilha de devolução](Trilhas/trilha_devolucao_venda.md). |
+
+Para o cenário e a interface da Manifestação, ver a [documentação dedicada](../Fiscal/documentacao_manifestacao_destinatario.md) e o [FAQ da Manifestação](../Fiscal/faq_manifestacao_destinatario.md).
+
+---
+
+## 🔗 Páginas-fonte
+
+- [FAQ — Movimentos (`201/202/203`)](Movimentos/faq.md)
+- [FAQ — Tipos de Movimento (`37`)](TiposDeMovimento/faq.md)
+- [FAQ — Importar XML (`204`)](faq_importar_xml.md)
+- [FAQ — Manifestação do Destinatário (`401`)](../Fiscal/faq_manifestacao_destinatario.md)
+- [Documentação — Ajuste de Estoque (`79`)](documentacao_ajuste_de_estoque.md)
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 1.0
+**Público-alvo**: Operação / Retaguarda / Suporte

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Use a **navegação à esquerda** ← para passear por módulos e submenus. No c
 
 ---
 
+## 🚪 Por onde começar
+
+| Você quer… | Vá para |
+|---|---|
+| 🧭 Entender **como o sistema pensa** antes de qualquer operação | [Visão geral do Sol.NET](visao_geral_sol_net.md) |
+| ❓ Resolver uma **tarefa específica** ("Quero saber o saldo", "Quero cancelar uma nota") | [Quero…](quero.md) |
+| 📖 Procurar o significado de um **termo** (NF-e, CFOP, Movimento, Tipo, Faturar…) | [Glossário](glossario.md) |
+| 📦 **Executar uma demanda do dia** de ponta a ponta (entrada de NF-e, venda completa, devolução, ajuste auditável) | [Trilhas operacionais de Movimentação](Movimentacao/Trilhas/) |
+| ⚠️ Entender uma **mensagem de erro** que apareceu | [Índice unificado de mensagens](Movimentacao/indice_mensagens.md) |
+
+---
+
 ## 🗺️ O ecossistema, num olhar
 
 | Módulo | O que você encontra aqui |
@@ -62,4 +74,4 @@ Toda página de documentação referencia as telas pelo **nome + código** (ex.:
 
 ---
 
-<p align="center"><sub>📅 Última atualização: Maio de 2026 · 📦 Versão 4.0 · 👥 Hetosoft — Sol.NET ERP</sub></p>
+<p align="center"><sub>📅 Última atualização: Maio de 2026 · 📦 Versão 4.1 · 👥 Hetosoft — Sol.NET ERP</sub></p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -498,6 +498,9 @@
 
         <nav class="sn-sidebar__nav">
           <a href="{{ '/' | relative_url }}" class="sn-sidebar__home{% if current == '/' or current == '/index.html' %} is-active{% endif %}">🏠 Início</a>
+          <a href="{{ '/visao-geral/' | relative_url }}" class="sn-sidebar__home">🧭 Visão geral do sistema</a>
+          <a href="{{ '/glossario/' | relative_url }}" class="sn-sidebar__home">📖 Glossário</a>
+          <a href="{{ '/quero/' | relative_url }}" class="sn-sidebar__home">❓ Quero…</a>
 
           <details class="sn-sidebar__group" data-sn-group="financeiro">
             <summary class="sn-sidebar__group-summary">💰 Financeiro</summary>
@@ -619,6 +622,19 @@
             <summary class="sn-sidebar__group-summary">📦 Movimentação</summary>
             <ul class="sn-sidebar__items">
               <li><a href="{{ '/Movimentacao/' | relative_url }}">Visão geral</a></li>
+              <li>
+                <details class="sn-sidebar__subgroup" data-sn-subgroup="trilhas">
+                  <summary class="sn-sidebar__subgroup-summary">🛤️ Trilhas operacionais</summary>
+                  <ul class="sn-sidebar__subitems">
+                    <li><a href="{{ '/Movimentacao/Trilhas/' | relative_url }}">Visão geral</a></li>
+                    <li><a href="{{ '/Movimentacao/Trilhas/trilha_entrada_nfe/' | relative_url }}">Entrada de NF-e completa</a></li>
+                    <li><a href="{{ '/Movimentacao/Trilhas/trilha_venda_completa/' | relative_url }}">Venda completa</a></li>
+                    <li><a href="{{ '/Movimentacao/Trilhas/trilha_devolucao_venda/' | relative_url }}">Devolução de venda</a></li>
+                    <li><a href="{{ '/Movimentacao/Trilhas/trilha_ajuste_estoque_auditoria/' | relative_url }}">Ajuste de estoque com auditoria</a></li>
+                  </ul>
+                </details>
+              </li>
+              <li><a href="{{ '/Movimentacao/indice_mensagens/' | relative_url }}">Índice de mensagens</a></li>
               <li>
                 <details class="sn-sidebar__subgroup" data-sn-subgroup="movimentos">
                   <summary class="sn-sidebar__subgroup-summary">Movimentos</summary>

--- a/glossario.md
+++ b/glossario.md
@@ -1,0 +1,266 @@
+---
+title: "Glossário do Sol.NET"
+permalink: /glossario/
+---
+
+# 📖 Glossário — Sol.NET
+
+## 🎯 Visão Geral
+
+Glossário central do Sol.NET ERP. Reúne os termos que aparecem todo dia na operação — documentos fiscais, conceitos de tributação, vocabulário de movimentação, estoque e financeiro. Cada termo tem definição curta e, quando faz sentido, lista as telas onde ele é usado.
+
+> 💡 **Como usar.** A maioria das páginas do portal aponta para este glossário na primeira vez que mencionam um termo. Cada termo aqui tem uma âncora estável — você pode linkar direto, ex.: `glossario.md#nf-e`.
+
+---
+
+## 🔤 Índice alfabético
+
+[CBS](#cbs) · [Cashback](#cashback) · [Centro de Custo](#centro-de-custo) · [CFOP](#cfop) · [Chave de Acesso](#chave-de-acesso) · [Conferência](#conferencia) · [CSOSN](#csosn) · [CST](#cst) · [CT-e](#ct-e) · [DANFE](#danfe) · [Estornar](#estornar) · [Faturar](#faturar) · [Finalizar](#finalizar) · [IBS](#ibs) · [ICMS](#icms) · [ICMS-ST](#icms-st) · [Local de Estoque](#local-de-estoque) · [Manifesto](#manifesto-do-destinatario) · [MDF-e](#mdf-e) · [Movimento](#movimento) · [Mudar](#mudar) · [NCM](#ncm) · [NF-e](#nf-e) · [NF-e de terceiros](#nf-e-de-terceiros) · [NF-e própria](#nf-e-propria) · [NSU](#nsu) · [Plano de Contas](#plano-de-contas) · [Quitar](#quitar) · [Reforma Tributária](#reforma-tributaria) · [Saldo](#saldo) · [Saldo PEPS](#saldo-peps) · [Tabela de Preço](#tabela-de-preco) · [Tipo de Movimento](#tipo-de-movimento) · [Transação de Estoque](#transacao-de-estoque)
+
+---
+
+## 📨 Documentos fiscais e SEFAZ
+
+### NF-e
+
+**Nota Fiscal Eletrônica** — documento fiscal eletrônico que registra a circulação de mercadorias entre empresas (B2B) ou para consumidor final. Autorizada pela SEFAZ do estado de origem, identificada por uma [Chave de Acesso](#chave-de-acesso) de 44 dígitos. Substitui a antiga nota fiscal modelo 1/1-A em papel.
+
+**Onde aparece:** [Importar XML](Movimentacao/documentacao_importar_xml.md) (`204`) · [Movimentos de Compras](Movimentacao/Movimentos/movimentos_de_compras.md) (`201`) · [Movimentos de Vendas](Movimentacao/Movimentos/movimentos_de_vendas.md) (`202`) · [Manifestação do Destinatário](Fiscal/documentacao_manifestacao_destinatario.md) (`401`)
+
+### NF-e própria {#nf-e-propria}
+
+NF-e em que **a empresa do Sol.NET é o emissor** — toda venda B2B que sai da empresa é uma NF-e própria. O XML é gerado pelo próprio Sol.NET, assinado e transmitido à SEFAZ.
+
+**Onde aparece:** [Movimentos de Vendas](Movimentacao/Movimentos/movimentos_de_vendas.md) (`202`) · [Importar XML](Movimentacao/documentacao_importar_xml.md) (`204`) (botão `Lançar Próprio` registra a saída no Sol.NET a partir de uma NF-e que a empresa emitiu por fora)
+
+### NF-e de terceiros
+
+NF-e em que **outra empresa é o emissor** e a empresa do Sol.NET é o destinatário — toda compra recebida é uma NF-e de terceiros. Chega via SEFAZ (a partir da [Manifestação](#manifesto-do-destinatario)) ou por importação manual do XML.
+
+**Onde aparece:** [Manifestação do Destinatário](Fiscal/documentacao_manifestacao_destinatario.md) (`401`) · [Importar XML](Movimentacao/documentacao_importar_xml.md) (`204`) · [Movimentos de Compras](Movimentacao/Movimentos/movimentos_de_compras.md) (`201`)
+
+### CT-e
+
+**Conhecimento de Transporte Eletrônico** — documento fiscal eletrônico que registra a prestação de serviço de transporte (frete de carga). Análogo à NF-e, mas para serviço de transporte: emitido pela transportadora, recebido pelo embarcador ou destinatário. Também passa por manifestação na [Manifestação do Destinatário](Fiscal/documentacao_manifestacao_destinatario.md).
+
+**Onde aparece:** [Manifestação do Destinatário](Fiscal/documentacao_manifestacao_destinatario.md) (`401`)
+
+### MDF-e
+
+**Manifesto Eletrônico de Documentos Fiscais** — documento que **agrupa** uma ou mais NF-e/CT-e em um mesmo transporte (uma carga, uma viagem, um veículo). Quem opera transporte próprio precisa emitir MDF-e para cada percurso, declarando o que está sendo levado, por onde e por quem.
+
+**Onde aparece:** sub-aba `MDF-e` dentro de [Movimentos](Movimentacao/Movimentos/documentacao_movimentos.md), quando o Tipo de Movimento envolve transporte próprio.
+
+### DANFE
+
+**Documento Auxiliar da NF-e** — versão impressa (PDF) da NF-e, usada para acompanhar a mercadoria no transporte e para o destinatário conferir. Não é o documento fiscal em si (esse é o XML autorizado), apenas a representação visual.
+
+**Onde aparece:** botão `DANFE` em [Importar XML](Movimentacao/documentacao_importar_xml.md) (`204`) e nos [Movimentos](Movimentacao/Movimentos/documentacao_movimentos.md) (`201/202/203`) após autorização da NF-e.
+
+### Chave de Acesso
+
+Sequência única de **44 dígitos** que identifica cada NF-e/NFC-e/CT-e/MDF-e autorizada pela SEFAZ. Funciona como o número de série do documento fiscal: dois documentos nunca têm a mesma chave. É o que o Sol.NET usa para amarrar uma NF-e recebida à compra correspondente.
+
+**Onde aparece:** grupo `Manifesto` em [Importar XML](Movimentacao/documentacao_importar_xml.md) (`204`) (display apenas — não é digitada) · [Manifestação do Destinatário](Fiscal/documentacao_manifestacao_destinatario.md) (`401`).
+
+### NSU
+
+**Número Sequencial Único** — número que a SEFAZ atribui a cada evento (NF-e, CT-e, manifestação, cancelamento etc.) que envolve a empresa. O Sol.NET usa o NSU para saber até qual ponto já consultou a SEFAZ — assim, da próxima vez, busca só o que é novo. Cada empresa tem seu próprio sequencial.
+
+**Onde aparece:** [Manifestação do Destinatário](Fiscal/documentacao_manifestacao_destinatario.md) (`401`) — botões `Zerar NSU` e demais controles do ciclo de consulta SEFAZ.
+
+### Manifestação do Destinatário {#manifesto-do-destinatario}
+
+Obrigação fiscal: para cada NF-e em que sua empresa é o destinatário, a SEFAZ exige que você se manifeste com **um dos quatro eventos** dentro do prazo legal:
+
+- **Ciência da Operação** — registra que tomou conhecimento da NF-e. Não compromete.
+- **Confirmação da Operação** — confirma que recebeu a mercadoria/serviço descrito na NF-e.
+- **Desconhecimento da Operação** — declara que não reconhece a NF-e (não comprou, não recebeu).
+- **Operação Não Realizada** — declara que a operação não foi concluída (devolução, recusa).
+
+A manifestação fecha a obrigação fiscal antes de qualquer lançamento no Sol.NET. Só depois disso o XML é processado pelo `Sol.NET MonitorNFCe` (ciclo automático, ~59 min) e fica disponível para lançamento na [Importar XML](Movimentacao/documentacao_importar_xml.md).
+
+**Onde aparece:** [Manifestação do Destinatário](Fiscal/documentacao_manifestacao_destinatario.md) (`401`).
+
+---
+
+## 🏛️ Tributação
+
+### CFOP
+
+**Código Fiscal de Operações e Prestações** — código de 4 dígitos definido pelo CONFAZ que classifica a natureza da operação fiscal (venda dentro do estado, venda interestadual, devolução, transferência, importação etc.). O primeiro dígito indica a abrangência geográfica (`1.xxx` = dentro do estado, `2.xxx` = interestadual, `3.xxx` = exterior, `5/6/7.xxx` = saída correspondente). Toda nota fiscal exige CFOP por item.
+
+**Onde aparece:** [Natureza de Operação](Fiscal/documentacao_natureza_operacao.md) (`36`) — é onde o CFOP é cadastrado e amarrado à operação.
+
+### CST
+
+**Código de Situação Tributária** — código que indica o tratamento tributário do produto na operação (tributado, isento, substituição tributária, suspenso, diferido etc.). Existe um CST para cada imposto (ICMS, PIS, COFINS, IPI). Empresas do regime normal usam CST de ICMS; empresas do Simples Nacional usam [CSOSN](#csosn).
+
+**Onde aparece:** [NCM](Fiscal/documentacao_ncm.md) (`21`) · [Natureza de Operação](Fiscal/documentacao_natureza_operacao.md) (`36`).
+
+### CSOSN
+
+**Código de Situação da Operação no Simples Nacional** — equivalente do [CST](#cst) de ICMS para empresas optantes pelo Simples Nacional. Usado quando a empresa emissora é do Simples (informa crédito de ICMS, ou ausência dele, para o destinatário).
+
+**Onde aparece:** [NCM](Fiscal/documentacao_ncm.md) (`21`).
+
+### NCM
+
+**Nomenclatura Comum do Mercosul** — código de 8 dígitos que classifica produtos para fins fiscais (federal e estadual). É a chave que governa qual alíquota de IPI, PIS, COFINS, ICMS, ICMS-ST e (no novo regime) [CBS](#cbs)/[IBS](#ibs) se aplica ao produto. No Sol.NET, o cadastro de NCM concentra as regras tributárias que serão aplicadas a todos os produtos vinculados àquele código.
+
+**Onde aparece:** [Cadastro de NCM](Fiscal/documentacao_ncm.md) (`21`) · [Cadastro de Produtos](Produtos/documentacao_produtos.md) (`32`) (campo `NCM`).
+
+### ICMS
+
+**Imposto sobre Circulação de Mercadorias e Serviços** — imposto estadual incidente sobre a maior parte das operações de venda, transferência e prestação de serviço de transporte/comunicação. Alíquotas variam por estado e por tipo de operação (interna, interestadual). No Sol.NET, as regras de ICMS por contexto vivem na [Região ICMS Saída](Fiscal/documentacao_regiao_icms.md) e por NCM no [Cadastro de NCM](Fiscal/documentacao_ncm.md).
+
+**Onde aparece:** [Região ICMS Saída](Fiscal/documentacao_regiao_icms.md) (`93`) · [NCM](Fiscal/documentacao_ncm.md) (`21`) · [Natureza de Operação](Fiscal/documentacao_natureza_operacao.md) (`36`).
+
+### ICMS-ST
+
+**Substituição Tributária do ICMS** — regime em que **um único elo da cadeia** (geralmente a indústria ou o importador) recolhe o ICMS de **todas as operações futuras** daquele produto, até o consumidor final. Para os demais elos (atacadistas, varejistas), o ICMS-ST entra como custo. Exige cálculo específico envolvendo Base de Cálculo, MVA (Margem de Valor Agregado) e alíquota interna do estado de destino.
+
+**Onde aparece:** [Região ICMS ST Saída](Fiscal/documentacao_regiao_icms_st_saida.md) (`94`) · [NCM](Fiscal/documentacao_ncm.md) (`21`).
+
+### CBS
+
+**Contribuição sobre Bens e Serviços** — tributo federal criado pela [Reforma Tributária](#reforma-tributaria) que substitui PIS, COFINS e parte do IPI. Apuração não-cumulativa, alíquota uniforme nacional. Em transição gradual até 2033.
+
+**Onde aparece:** [Reforma Tributária](Fiscal/documentacao_reforma_tributaria.md) · [NCM](Fiscal/documentacao_ncm.md) (`21`) (campos de tributação CBS).
+
+### IBS
+
+**Imposto sobre Bens e Serviços** — tributo de competência compartilhada entre Estados e Municípios, criado pela [Reforma Tributária](#reforma-tributaria) para substituir ICMS e ISS. Alíquota composta pela soma de uma parte estadual e uma municipal, definida no destino da operação.
+
+**Onde aparece:** [Reforma Tributária](Fiscal/documentacao_reforma_tributaria.md) · [NCM](Fiscal/documentacao_ncm.md) (`21`) (campos de tributação IBS).
+
+### Reforma Tributária {#reforma-tributaria}
+
+Mudança no sistema tributário brasileiro (EC 132/2023) que substitui **PIS + COFINS + IPI** por **[CBS](#cbs)** e **ICMS + ISS** por **[IBS](#ibs)**, com transição gradual entre 2026 e 2033. Cria também o **Imposto Seletivo (IS)** para produtos específicos. A documentação dedicada cobre cronograma, parametrização e impacto nas telas do Sol.NET.
+
+**Onde aparece:** [Reforma Tributária — documentação completa](Fiscal/documentacao_reforma_tributaria.md).
+
+---
+
+## 📦 Movimentação
+
+### Movimento
+
+**Documento operacional** que registra toda transação relevante: compra recebida, venda emitida, transferência entre filiais, devolução, produção, ajuste de inventário. É a unidade central da operação no Sol.NET. Cada movimento amarra **um** [Tipo de Movimento](#tipo-de-movimento) e herda dele todas as regras (efeito no estoque, financeiro gerado, fiscal emitido).
+
+O mesmo formulário operacional é exposto sob três códigos na pesquisa F1, conforme o `Comportamento` do Tipo: `201` (Entrada/Compras), `202` (Saída/Vendas), `203` (Outros).
+
+**Onde aparece:** [Movimentos — referência completa](Movimentacao/Movimentos/documentacao_movimentos.md) · [Movimentos de Compras](Movimentacao/Movimentos/movimentos_de_compras.md) (`201`) · [Movimentos de Vendas](Movimentacao/Movimentos/movimentos_de_vendas.md) (`202`) · [Outros Movimentos](Movimentacao/Movimentos/outros_movimentos.md) (`203`).
+
+### Tipo de Movimento
+
+**Cadastro de configuração** que define o comportamento do [Movimento](#movimento): qual [Transação de Estoque](#transacao-de-estoque) aplicar, qual fiscal emitir, se gera financeiro (e qual), qual Tabela de Preço usar por padrão, quais campos do cabeçalho são obrigatórios, quais sub-abas ficam visíveis, quais validações disparar. É a tela mais importante para entender qualquer movimento — o movimento em si só registra valores; o Tipo decide o que esses valores significam para o sistema.
+
+**Onde aparece:** [Tipos de Movimento](Movimentacao/TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`).
+
+### Transação de Estoque {#transacao-de-estoque}
+
+**Cadastro** que define o efeito de um movimento em cada **camada de saldo** (Físico, Disponível, Reservado, Negociado etc.). Uma Transação pode somar no Físico e Disponível (entrada de compra), subtrair de ambos (venda balcão), subtrair só do Disponível e somar no Reservado (reserva), e assim por diante. Cada [Tipo de Movimento](#tipo-de-movimento) aponta para uma Transação — é o que decide se um movimento entra, sai, transfere ou apenas reserva mercadoria.
+
+**Onde aparece:** [Transações de Estoque](Movimentacao/documentacao_transacoes_de_estoque.md) (`33`).
+
+### Conferência {#conferencia}
+
+Etapa intermediária — entre o recebimento da NF-e e o lançamento do movimento — em que um conferente confirma fisicamente, item a item, se a mercadoria recebida confere com a NF-e em quantidade e identificação. Acontece dentro da [Importar XML](Movimentacao/documentacao_importar_xml.md) (`204`), na sub-aba `Conferência`, e é habilitada por loja no `Cadastro de Empresas`. A conferência é registrada pelo app **Sol.NET Administrativo** (a aba `Conferência` da tela `204` apenas **exibe** o resultado).
+
+**Onde aparece:** [Conferência de XML](Movimentacao/documentacao_conferencia_xml.md) · sub-aba `Conferência` em [Importar XML](Movimentacao/documentacao_importar_xml.md) (`204`).
+
+### Cashback
+
+Crédito que o cliente recebe sobre o valor da compra, para usar em compras futuras. No Sol.NET, é configurado por [Tipo de Movimento](#tipo-de-movimento) e por regras (percentual, validade, valor mínimo) na tela `Regras Cashback`. Predominantemente usado pelo PDV (frente de caixa); na retaguarda, o cashback aparece nas sub-abas `Crédito Pessoa — Gerado` e `Crédito Pessoa — Usado` do movimento.
+
+**Onde aparece:** [Regras Cashback](Movimentacao/documentacao_regras_cashback.md) (`124`).
+
+---
+
+## 🗃️ Estoque e produtos
+
+### Local de Estoque
+
+**Armazém, loja ou depósito físico** onde o saldo da mercadoria vive. Cada movimento que afeta estoque exige um Local de origem (saída) e/ou destino (entrada). O [Saldo](#saldo) é sempre **por produto × Local**: o mesmo produto pode ter 50 unidades em uma loja e 0 em outra.
+
+**Onde aparece:** [Locais de Estoque](Movimentacao/documentacao_locais_de_estoque.md) (`28`).
+
+### Saldo
+
+Quantidade do produto disponível em cada **camada** dentro de cada [Local de Estoque](#local-de-estoque). As camadas mais comuns são **Físico** (o que está no armazém), **Disponível** (o que pode ser vendido — Físico − reservas) e **Negociado** (vendido mas ainda não entregue). Cada [Transação de Estoque](#transacao-de-estoque) define em quais camadas o movimento soma ou subtrai.
+
+**Onde aparece:** [Saldo Estoque](Movimentacao/documentacao_saldo_estoque.md) (`78`) · [Histórico de Produtos](Movimentacao/documentacao_historico_de_produtos.md) (`206`).
+
+### Saldo PEPS
+
+**Primeiro que Entra, Primeiro que Sai** — método de avaliação de estoque em que a saída consome primeiro a camada mais antiga. Influencia o **custo médio** registrado, porque cada entrada com custo diferente vira uma camada FIFO, e a saída custeia a camada mais antiga. Usado pelo Sol.NET quando o produto é configurado para controle PEPS.
+
+**Onde aparece:** [Saldo Estoque](Movimentacao/documentacao_saldo_estoque.md) (`78`).
+
+### Tabela de Preço {#tabela-de-preco}
+
+**Cadastro** que define o preço de venda de cada produto **por contexto** (loja, condição de pagamento, faixa de cliente, período promocional). Cada [Tipo de Movimento](#tipo-de-movimento) aponta para uma Tabela padrão; o movimento pode usar a Tabela do Tipo ou outra escolhida no cabeçalho.
+
+**Onde aparece:** [Tabela de Preço](Movimentacao/documentacao_tabela_de_preco.md) (`27`).
+
+---
+
+## ⚙️ Verbos da operação
+
+### Faturar
+
+Termo genérico para **emitir nota fiscal de venda** — converter um orçamento/pedido em uma NF-e/NFC-e autorizada pela SEFAZ. No Sol.NET, faturar normalmente passa por [Mudar](#mudar) o movimento para um Tipo que emite documento fiscal (ou por finalizar uma venda direta no `202`), seguido da emissão fiscal.
+
+**Onde aparece:** [Movimentos de Vendas](Movimentacao/Movimentos/movimentos_de_vendas.md) (`202`) · [Movimentos — referência](Movimentacao/Movimentos/documentacao_movimentos.md).
+
+### Finalizar
+
+Operação que **consolida** um movimento: gera o financeiro definitivo, baixa o estoque conforme a Transação amarrada e (se aplicável) emite o documento fiscal. Antes de finalizar, o sistema dispara dezenas de validações cruzadas (caixa aberto, série fiscal disponível, campos obrigatórios, totalizações consistentes).
+
+**Onde aparece:** [Movimentos — referência](Movimentacao/Movimentos/documentacao_movimentos.md) — operação central de qualquer movimento.
+
+### Mudar
+
+Operação que **converte um movimento de um Tipo para outro** conforme regras configuradas em `Tipos de Movimento → aba Mudar`. Típico no ciclo `ORÇAMENTO → PEDIDO → VENDA`. O Tipo de destino decide o comportamento da mudança em **um de dois modos**:
+
+- **Transformar** — o mesmo movimento muda de Tipo. O identificador interno é preservado.
+- **Duplicar** — um novo movimento é criado; o original muda de status para `VINCULADO` e fica congelado, formando uma pilha auditável.
+
+A escolha entre Transformar e Duplicar é decidida pelo cadastro do Tipo de destino, não pelo operador.
+
+**Onde aparece:** [Movimentos — referência](Movimentacao/Movimentos/documentacao_movimentos.md) (seção `Mudar`).
+
+### Quitar
+
+Operação que **liquida os títulos do contas a Pagar/Receber** ligados a um movimento. Pode ser por total, por título individual ou por agrupamento. As variantes incluem `Quitar Múltiplo`, `Quitar Contas PR` e `Quitar/Imprimir Só Portador`.
+
+**Onde aparece:** [Movimentos — referência](Movimentacao/Movimentos/documentacao_movimentos.md) · [Quitação](Financeiro/documentacao_quitacao.md) (`303`) · [Pagar e Receber](Financeiro/documentacao_pagar_e_receber.md) (`301`).
+
+### Estornar
+
+Operação que **reverte completamente o efeito de um movimento** — devolve saldo ao estoque, cancela financeiro e cancela documento fiscal (quando permitido pela SEFAZ). A reversão é registrada e gera trilha de auditoria visível em [Histórico de Movimentações](Movimentacao/documentacao_historico_de_movimentacoes.md) (`205`).
+
+**Onde aparece:** [Movimentos — referência](Movimentacao/Movimentos/documentacao_movimentos.md) (seção `Estornar`).
+
+---
+
+## 💰 Financeiro
+
+### Centro de Custo
+
+Unidade de **rateio gerencial** das despesas e receitas — departamento, projeto, frota, loja. Cada lançamento financeiro pode ser rateado entre um ou mais centros de custo para fins de análise de resultado por área.
+
+**Onde aparece:** [Centros de Custos](Financeiro/documentacao_centros_de_custos.md).
+
+### Plano de Contas
+
+Estrutura hierárquica que classifica as **contas contábeis e gerenciais** da empresa (receitas, despesas, ativos, passivos). Toda movimentação financeira lançada no Sol.NET aponta para uma conta do Plano — é o que permite gerar DRE, balanço e relatórios gerenciais por conta.
+
+**Onde aparece:** [Plano de Contas](Financeiro/documentacao_plano_de_contas.md).
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 1.0
+**Público-alvo**: Todos os usuários do Sol.NET

--- a/glossario.md
+++ b/glossario.md
@@ -239,7 +239,7 @@ Operação que **liquida os títulos do contas a Pagar/Receber** ligados a um mo
 
 ### Estornar
 
-Operação que **reverte completamente o efeito de um movimento** — devolve saldo ao estoque, cancela financeiro e cancela documento fiscal (quando permitido pela SEFAZ). A reversão é registrada e gera trilha de auditoria visível em [Histórico de Movimentações](Movimentacao/documentacao_historico_de_movimentacoes.md) (`205`).
+Operação que **reverte completamente o efeito de um movimento** — devolve saldo ao estoque, cancela financeiro e cancela documento fiscal (quando permitido pela SEFAZ). O movimento estornado aparece nos relatórios de movimentação como estornado/cancelado.
 
 **Onde aparece:** [Movimentos — referência](Movimentacao/Movimentos/documentacao_movimentos.md) (seção `Estornar`).
 

--- a/llms.txt
+++ b/llms.txt
@@ -7,6 +7,9 @@ Toda tela do Sol.NET é acessada pela pesquisa universal (atalho `F1`), digitand
 ## Portal
 
 - [Início](https://hetosoft.github.io/documentacao-solnet/): página inicial do portal, com o ecossistema de módulos.
+- [Visão geral do Sol.NET](https://hetosoft.github.io/documentacao-solnet/visao-geral/): modelo mental do sistema — eixo Movimento ↔ Tipo de Movimento ↔ Transação de Estoque ↔ Estoque/Financeiro/Fiscal, 3 dimensões de qualquer operação, mapa "Quero…" e 7 verbos do dia.
+- [Glossário](https://hetosoft.github.io/documentacao-solnet/glossario/): glossário central de termos do Sol.NET (NF-e, CT-e, NCM, CFOP, CST, NSU, Manifesto, Movimento, Tipo de Movimento, Transação, Faturar, Quitar, Estornar etc.) com âncoras para deep-link.
+- [Quero…](https://hetosoft.github.io/documentacao-solnet/quero/): índice de tarefas em primeira pessoa ("Quero saber quanto tenho", "Quero cancelar uma nota") que aponta para a tela ou trilha certa.
 
 ## Financeiro
 
@@ -62,6 +65,12 @@ Toda tela do Sol.NET é acessada pela pesquisa universal (atalho `F1`), digitand
 ## Movimentação
 
 - [Visão geral do módulo Movimentação](https://hetosoft.github.io/documentacao-solnet/Movimentacao/): índice da seção.
+- [Trilhas operacionais — visão geral](https://hetosoft.github.io/documentacao-solnet/Movimentacao/Trilhas/): índice das trilhas narrativas que atravessam múltiplas telas para cobrir uma demanda real ponta a ponta.
+- [Trilha — Entrada de NF-e completa](https://hetosoft.github.io/documentacao-solnet/Movimentacao/Trilhas/trilha_entrada_nfe/): manifestação → Importar XML → conferência → Movimentos de Compras (201) → estoque + título Pagar.
+- [Trilha — Venda completa](https://hetosoft.github.io/documentacao-solnet/Movimentacao/Trilhas/trilha_venda_completa/): Movimentos de Vendas (202) → ciclo Orçamento/Pedido/Venda → emissão fiscal → Quitação.
+- [Trilha — Devolução de venda](https://hetosoft.github.io/documentacao-solnet/Movimentacao/Trilhas/trilha_devolucao_venda/): Outros Movimentos (203) com Tipo Devolução de Venda, referência à nota original e padrão de duas etapas para cupom NFC-e.
+- [Trilha — Ajuste de estoque com auditoria](https://hetosoft.github.io/documentacao-solnet/Movimentacao/Trilhas/trilha_ajuste_estoque_auditoria/): Ajuste de Estoque (79) → movimentos em 203 → auditoria em Histórico de Produtos (206) e Saldo Estoque (78).
+- [Índice unificado de mensagens](https://hetosoft.github.io/documentacao-solnet/Movimentacao/indice_mensagens/): tabela consolidada das mensagens de validação das telas 201/202/203, 37, 204 e 401, com causa provável e link para a FAQ detalhada.
 - [Movimentos — visão geral](https://hetosoft.github.io/documentacao-solnet/Movimentacao/Movimentos/): índice dos documentos de Movimentos.
 - [Movimentos — referência](https://hetosoft.github.io/documentacao-solnet/Movimentacao/Movimentos/documentacao_movimentos/): referência transversal de Movimentos (201/202/203).
 - [Movimentos de Compras](https://hetosoft.github.io/documentacao-solnet/Movimentacao/Movimentos/movimentos_de_compras/): tela Compras (código 201).

--- a/quero.md
+++ b/quero.md
@@ -49,9 +49,9 @@ Cada entrada mostra a pergunta em primeira pessoa, a resposta curta e onde ir.
 
 → Abra [Tabela de Preço](Movimentacao/documentacao_tabela_de_preco.md) (`27`). Veja qual Tabela está vinculada ao Tipo de Movimento que você usa (na tela `Tipos de Movimento`, código `37`) e ajuste lá.
 
-### Quero ver o que aconteceu numa data específica (movimentos do dia)
+### Quero ver os totais de vendas (por dia, vendedor, portador, condição)
 
-→ Abra [Histórico de Movimentações](Movimentacao/documentacao_historico_de_movimentacoes.md) (`205`) e filtre pelo período.
+→ Abra [Histórico de Movimentações](Movimentacao/documentacao_historico_de_movimentacoes.md) (`205`) e filtre pelo período. As sub-abas agregam por data, mês, pessoa, tipo, portador, condição de pagamento, vendedor, operador e tabela de preço; a aba `Comissão` calcula comissão sobre vendas e devoluções.
 
 ### Quero entender uma mensagem de erro que apareceu
 

--- a/quero.md
+++ b/quero.md
@@ -1,0 +1,128 @@
+---
+title: "Quero… — Índice por tarefa"
+permalink: /quero/
+---
+
+# 📄 Quero… — Índice por tarefa
+
+## 🎯 Visão Geral
+
+Índice **orientado à pergunta do usuário**, não à tela. Se você sabe **o que quer fazer** mas não tem certeza por onde começar, este é o atalho.
+
+Cada entrada mostra a pergunta em primeira pessoa, a resposta curta e onde ir.
+
+> 💡 Para entender o vocabulário usado nas respostas, abra o [Glossário](glossario.md). Para o modelo mental do sistema, comece pela [Visão geral](visao_geral_sol_net.md).
+
+---
+
+## 📦 Movimentação — estoque, vendas, compras
+
+### Quero saber quanto tenho de um produto
+
+→ Abra [Saldo Estoque](Movimentacao/documentacao_saldo_estoque.md) (`78`). Filtre por produto e/ou Local. Mostra todas as camadas (Físico, Disponível, Reservado etc.).
+
+### Quero entender por que o saldo de um produto está errado
+
+→ Abra [Histórico de Produtos](Movimentacao/documentacao_historico_de_produtos.md) (`206`). Lista cada movimento que tocou o saldo desse produto, em ordem. Combine com a [Trilha de auditoria de ajuste](Movimentacao/Trilhas/trilha_ajuste_estoque_auditoria.md) se a divergência for de ajuste manual.
+
+### Quero lançar uma nota de entrada (compra com NF-e do fornecedor)
+
+→ Siga a [Trilha de entrada de NF-e](Movimentacao/Trilhas/trilha_entrada_nfe.md) — passa por [Manifestação](Fiscal/documentacao_manifestacao_destinatario.md) → [Importar XML](Movimentacao/documentacao_importar_xml.md) → [Conferência](Movimentacao/documentacao_conferencia_xml.md) → [Movimentos de Compras](Movimentacao/Movimentos/movimentos_de_compras.md) (`201`).
+
+### Quero faturar uma venda do começo ao fim
+
+→ Siga a [Trilha de venda completa](Movimentacao/Trilhas/trilha_venda_completa.md) — pedido/orçamento → [Movimentos de Vendas](Movimentacao/Movimentos/movimentos_de_vendas.md) (`202`) → emissão fiscal → [Quitação](Financeiro/documentacao_quitacao.md).
+
+### Quero fazer devolução de uma venda
+
+→ Siga a [Trilha de devolução de venda](Movimentacao/Trilhas/trilha_devolucao_venda.md) — abre em [Outros Movimentos](Movimentacao/Movimentos/outros_movimentos.md) (`203`) com Tipo `Devolução de Venda` e Movimento Referenciado para a venda original.
+
+### Quero estornar (cancelar) um movimento já finalizado
+
+→ Na tela do Movimento (`201`/`202`/`203`), localize o registro e use `F11` ou o botão `Estornar`. Reverte estoque, financeiro e fiscal (se a SEFAZ permitir). Detalhes na [referência de Movimentos](Movimentacao/Movimentos/documentacao_movimentos.md) (seção `Estornar`).
+
+### Quero ajustar saldo de um produto
+
+→ Abra [Ajuste de Estoque](Movimentacao/documentacao_ajuste_de_estoque.md) (`79`). Para um ajuste rastreável com auditoria posterior, siga a [Trilha de ajuste com auditoria](Movimentacao/Trilhas/trilha_ajuste_estoque_auditoria.md).
+
+### Quero ajustar o preço de venda de um produto
+
+→ Abra [Tabela de Preço](Movimentacao/documentacao_tabela_de_preco.md) (`27`). Veja qual Tabela está vinculada ao Tipo de Movimento que você usa (na tela `Tipos de Movimento`, código `37`) e ajuste lá.
+
+### Quero ver o que aconteceu numa data específica (movimentos do dia)
+
+→ Abra [Histórico de Movimentações](Movimentacao/documentacao_historico_de_movimentacoes.md) (`205`) e filtre pelo período.
+
+### Quero entender uma mensagem de erro que apareceu
+
+→ Veja o [Índice unificado de mensagens](Movimentacao/indice_mensagens.md). Lista mensagem por mensagem com causa provável e onde resolver.
+
+### Quero saber por que meu Movimento gerou (ou não gerou) financeiro
+
+→ Olhe o `Tipo de Movimento` que está sendo usado, em `37`. A flag `Gerar Lançamento Financeiro` (e configurações relacionadas) decide. Conceito mais amplo na [Visão geral — 3 dimensões](visao_geral_sol_net.md#-as-3-dimens%C3%B5es-de-qualquer-opera%C3%A7%C3%A3o).
+
+### Quero saber por que meu Movimento não baixou o estoque
+
+→ Olhe a `Transação de Estoque` amarrada ao Tipo do Movimento, em `33`. Confira as colunas `Físico` e `Disponível`. Local de Estoque no Cabeçalho também influencia — o saldo é por Local.
+
+### Quero produzir um item a partir de uma fórmula
+
+→ Abra [Produção de Produtos](Movimentacao/Producao/documentacao_producao_de_produtos.md) (`144`). A fórmula em si é cadastrada em [Fórmula de Produtos](Movimentacao/Producao/documentacao_formulas_de_produtos.md) (`143`).
+
+### Quero configurar/ajustar cashback do PDV
+
+→ Abra [Regras Cashback](Movimentacao/documentacao_regras_cashback.md) (`124`).
+
+---
+
+## 💰 Financeiro
+
+### Quero quitar um título a pagar ou a receber
+
+→ Abra [Quitação](Financeiro/documentacao_quitacao.md) (`303`) para quitação em lote ou pelo movimento de origem, ou abra o título em [Pagar e Receber](Financeiro/documentacao_pagar_e_receber.md) (`301`) e quite individualmente.
+
+### Quero ver os títulos abertos de um cliente ou fornecedor
+
+→ Abra [Pagar e Receber](Financeiro/documentacao_pagar_e_receber.md) (`301`) e filtre pela Pessoa.
+
+### Quero operar o caixa do dia (abertura, lançamentos, fechamento)
+
+→ Abra [Caixa Geral — operação](Financeiro/documentacao_caixa_geral_op.md) (`302`).
+
+---
+
+## 🏛️ Fiscal
+
+### Quero manifestar (Ciência / Confirmação / Desconhecimento) uma NF-e que entrou
+
+→ Abra [Manifestação do Destinatário](Fiscal/documentacao_manifestacao_destinatario.md) (`401`). É a primeira etapa antes de qualquer lançamento de entrada.
+
+### Quero entender como Reforma Tributária (CBS/IBS) afeta minha operação
+
+→ Leia [Reforma Tributária — Documentação](Fiscal/documentacao_reforma_tributaria.md) e o [Guia Rápido](Fiscal/guia_rapido_reforma_tributaria.md).
+
+### Quero acertar a regra de ICMS para um estado/contexto
+
+→ [Região ICMS Saída](Fiscal/documentacao_regiao_icms.md) (`93`) para ICMS regular; [Região ICMS ST Saída](Fiscal/documentacao_regiao_icms_st_saida.md) (`94`) para Substituição Tributária.
+
+### Quero cadastrar uma nova Natureza de Operação (CFOP)
+
+→ Abra [Natureza de Operação](Fiscal/documentacao_natureza_operacao.md) (`36`).
+
+---
+
+## 🏷️ Produtos
+
+### Quero cadastrar um produto novo
+
+→ Abra [Cadastro de Produtos](Produtos/documentacao_produtos.md) (`32`). Para a visão por checklist, use o [Guia Rápido](Produtos/guia_rapido.md).
+
+### Quero saber por que o sistema diz que o código/descrição do produto já existe
+
+→ Veja a [FAQ de Produtos](Produtos/faq.md) — seção sobre validação de código/descrição duplicada.
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 1.0
+**Público-alvo**: Todos os usuários do Sol.NET

--- a/visao_geral_sol_net.md
+++ b/visao_geral_sol_net.md
@@ -1,0 +1,173 @@
+---
+title: "Como o Sol.NET pensa — Visão geral"
+permalink: /visao-geral/
+---
+
+# 📄 Como o Sol.NET pensa — Visão geral do sistema
+
+## 🎯 Visão Geral
+
+Esta página explica **o modelo mental** do Sol.NET — como o sistema enxerga uma operação por dentro, em vez de descrever telas individuais. É o que faltava ler antes de abrir qualquer documentação específica.
+
+> 💡 **Quando voltar aqui.** Sempre que uma tela parecer ter "regras estranhas" que vêm de outro lugar. Quase sempre vêm de um dos elos descritos abaixo.
+
+---
+
+## 🧭 O eixo central
+
+Toda operação que mexe com **mercadoria, dinheiro ou documento fiscal** passa por uma cadeia única:
+
+```mermaid
+flowchart TD
+  M[Movimento<br/><i>o documento da operação</i>] --> T[Tipo de Movimento<br/><i>a configuração das regras</i>]
+  T --> X[Transação de Estoque<br/><i>o efeito em cada camada de saldo</i>]
+  T --> F[Financeiro<br/><i>se gera título, qual e para quem</i>]
+  T --> S[Fiscal<br/><i>se emite NF-e/NFC-e/CT-e, qual CFOP</i>]
+  X --> E[(Saldo por Local)]
+  F --> CP[(Contas a Pagar / Receber)]
+  S --> NF[(NF-e autorizada na SEFAZ)]
+```
+
+Leia este diagrama da seguinte forma:
+
+- O **Movimento** é o documento (linha que aparece no grid `201`/`202`/`203`).
+- O **Tipo de Movimento** é o "molde" — quem decide tudo que o Movimento vai fazer.
+- A partir do Tipo, três caminhos paralelos: **Estoque**, **Financeiro**, **Fiscal**. Cada um pode ser acionado, ou não, conforme o Tipo configurar.
+
+> 💡 **A regra de ouro.** Quando uma tela "se comporta diferente do esperado", a resposta quase sempre está no `Tipo de Movimento` que está sendo usado, não no Movimento em si. O Tipo é a tela mais importante de entender em conjunto com qualquer Movimento.
+
+Para uma visão expandida e visual, há o mapa completo do sistema em [`Assets/SolNET Mindmap.svg`]({{ '/Assets/SolNET Mindmap.svg' | relative_url }}).
+
+---
+
+## 🔍 As 3 dimensões de qualquer operação
+
+Toda operação no Sol.NET — desde uma venda simples até uma transferência entre filiais — responde a **três perguntas**. O [Tipo de Movimento](glossario.md#tipo-de-movimento) (`37`) é onde essas três respostas são configuradas.
+
+### 1. Estoque — entra, sai, transfere ou nada?
+
+O Tipo aponta para uma [Transação de Estoque](glossario.md#transacao-de-estoque) (`33`), que decide o efeito em cada **camada** de [Saldo](glossario.md#saldo):
+
+- Entrada de compra: soma em `Físico` e `Disponível`.
+- Venda balcão: subtrai de `Físico` e `Disponível`.
+- Reserva de pedido: subtrai de `Disponível`, soma em `Reservado`.
+- Transferência entre filiais: subtrai do Local origem, soma no Local destino.
+- Ajuste positivo/negativo: soma ou subtrai sem contrapartida.
+
+O **Local de Estoque** sempre entra na conta — saldo é por produto × Local.
+
+### 2. Financeiro — gera título? Quando? Para quem?
+
+O Tipo decide se um título de Pagar/Receber é gerado no momento da finalização, qual é o tipo de título, e qual a Condição de Pagamento padrão. Pode também:
+
+- **Não gerar nada** (transferência entre filiais, ajuste de inventário, produção — não há dinheiro envolvido).
+- **Gerar Pagar** (compra de fornecedor).
+- **Gerar Receber** (venda a prazo).
+- **Gerar Crédito de Pessoa** (devolução de venda que vira saldo a favor do cliente).
+
+### 3. Fiscal — emite documento? Recebe? Qual CFOP?
+
+O Tipo aponta para uma [Natureza de Operação](glossario.md#cfop) (`36`), que carrega o **CFOP** e as demais regras tributárias. Pode:
+
+- **Emitir NF-e/NFC-e/NFS-e** (venda, transferência, devolução).
+- **Receber e referenciar XML de terceiros** (compra com NF-e do fornecedor).
+- **Não emitir nada** (ajuste interno).
+
+Comportamentos como obrigatoriedade de referenciar nota (em devoluções), exigência de Chave de Acesso, modelo fiscal e série também são herdados via Tipo.
+
+---
+
+## 🗺️ Onde acontece cada coisa
+
+Mapa rápido das telas mais usadas, organizadas pela tarefa do dia:
+
+| Quero… | Vá para |
+|---|---|
+| Vender (balcão, prazo, OS) | [Movimentos de Vendas](Movimentacao/Movimentos/movimentos_de_vendas.md) (`202`) |
+| Receber uma NF-e de compra | [Manifestação](Fiscal/documentacao_manifestacao_destinatario.md) (`401`) → [Importar XML](Movimentacao/documentacao_importar_xml.md) (`204`) → [Movimentos de Compras](Movimentacao/Movimentos/movimentos_de_compras.md) (`201`) |
+| Devolver uma venda, transferir entre lojas, ajustar inventário | [Outros Movimentos](Movimentacao/Movimentos/outros_movimentos.md) (`203`) |
+| Ajustar saldo manualmente | [Ajuste de Estoque](Movimentacao/documentacao_ajuste_de_estoque.md) (`79`) — gera movimento visível em `203` |
+| Saber quanto tenho de um produto | [Saldo Estoque](Movimentacao/documentacao_saldo_estoque.md) (`78`) |
+| Entender por que o saldo está assim | [Histórico de Produtos](Movimentacao/documentacao_historico_de_produtos.md) (`206`) |
+| Auditar um movimento (quem alterou, quando) | [Histórico de Movimentações](Movimentacao/documentacao_historico_de_movimentacoes.md) (`205`) |
+| Lançar/quitar um título | [Pagar e Receber](Financeiro/documentacao_pagar_e_receber.md) (`301`) · [Quitação](Financeiro/documentacao_quitacao.md) (`303`) |
+| Operar caixa diário | [Caixa Geral — operação](Financeiro/documentacao_caixa_geral_op.md) (`302`) |
+| Configurar como um Tipo se comporta | [Tipos de Movimento](Movimentacao/TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) |
+| Ajustar preço de venda de produtos | [Tabela de Preço](Movimentacao/documentacao_tabela_de_preco.md) (`27`) |
+
+Toda tela é aberta pela **pesquisa universal (`F1`)** — digite nome ou código.
+
+---
+
+## 🔁 Os 7 verbos do dia
+
+Quase tudo que se faz com um Movimento se resume a sete verbos. Eles aparecem nos botões da tela e no ciclo de vida do documento:
+
+| Verbo | O que faz | Atalho | Onde |
+|---|---|---|---|
+| **Lançar** | Grava um novo Movimento (em estado aberto, pronto pra ajuste). | (botão `Novo` / `Gravar`) | `201/202/203` |
+| **Finalizar** | Consolida — gera financeiro, baixa estoque, emite fiscal se aplicável. | `F6` | `201/202/203` |
+| **Mudar** | Converte o Movimento para outro Tipo (orçamento→pedido→venda). Pode `Transformar` (mesmo Movimento) ou `Duplicar` (novo Movimento + original `VINCULADO`). | `F7` | `201/202/203` |
+| **Quitar** | Liquida o(s) título(s) financeiro(s) gerados. | `F8` | `201/202/203`, [Pagar e Receber](Financeiro/documentacao_pagar_e_receber.md), [Quitação](Financeiro/documentacao_quitacao.md) |
+| **Imprimir** | Aciona o modelo de impressão configurado no Tipo (DANFE, comprovante, OS). | `F9` | `201/202/203` |
+| **Emitir** | Transmite o documento eletrônico à SEFAZ (NF-e/NFC-e/NFS-e). | `F10` | `201/202/203` |
+| **Estornar** | Reverte completamente — devolve saldo, cancela financeiro e fiscal. | `F11` | `201/202/203` |
+
+> ⚠️ Os atalhos `F6`–`F11` só funcionam **fora** do modo de pesquisa. Dentro da lista de busca, ficam inativos.
+
+Cada um desses verbos tem detalhes (modos, validações, particularidades) cobertos na [referência completa de Movimentos](Movimentacao/Movimentos/documentacao_movimentos.md).
+
+---
+
+## 💡 Exemplos práticos do modelo mental em ação
+
+### Exemplo 1 — Por que minha venda não baixou o estoque?
+
+O Movimento foi finalizado, mas o saldo continua igual. Olhando o **eixo central**: a falha está entre `Tipo de Movimento → Transação de Estoque`. O Tipo usado aponta para uma Transação que **não subtrai** do Físico/Disponível, ou aponta para uma Transação que afeta uma camada que você não está consultando.
+
+**Como confirmar:** abra o Tipo do Movimento em `37`; veja qual `Transação de Estoque` está vinculada; abra a Transação em `33` e confira as colunas `Físico` e `Disponível`.
+
+### Exemplo 2 — Por que apareceu um título a pagar inesperado?
+
+Lançou um movimento como "transferência" mas um título de Pagar foi gerado. Olhando o eixo: a configuração do Tipo está com `Gerar Lançamento Financeiro` ativo. Transferências reais entre filiais não geram financeiro — o Tipo precisa estar configurado sem isso.
+
+### Exemplo 3 — Por que devolução de venda fica em `203` e não em `202`?
+
+A divisão entre `201/202/203` segue **dois critérios** combinados: o `Comportamento` do Tipo (Entrada/Saída/Outros) e o **fluxo operacional** de quem usa. Devolução de venda envolve mercadoria entrando de volta, mas é operada pela retaguarda (não pelo vendedor) — por isso vai em `203`, com Tipos de Comportamento `Outros`, e não em `202`.
+
+---
+
+## ❓ FAQ / Problemas comuns
+
+**Onde aprendo "tudo" sobre Movimentos?**
+A [referência completa de Movimentos](Movimentacao/Movimentos/documentacao_movimentos.md) cobre o ciclo de vida, todas as sub-abas (consulta e lançamento), validações principais e telas relacionadas. É a leitura mais densa do portal.
+
+**E sobre Tipos de Movimento?**
+[Tipos de Movimento — documentação](Movimentacao/TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) cobre as 12 abas de configuração e 50+ validações. A [referência de configurações](Movimentacao/TiposDeMovimento/referencia_configuracoes_tipos_movimento.md) detalha cada flag.
+
+**Quero seguir um caminho ponta a ponta, não ler tela por tela.**
+Vá direto para as [Trilhas operacionais](Movimentacao/Trilhas/) — guias narrativos que atravessam as telas na ordem de uma demanda real (entrada de NF-e, venda completa, devolução, ajuste com auditoria).
+
+**Não sei por qual tela começar a resolver meu problema.**
+Veja o [índice "Quero…"](quero.md) — entrada orientada à tarefa.
+
+**Preciso conferir o significado de um termo.**
+[Glossário](glossario.md) — definições com link para as telas que usam cada termo.
+
+---
+
+## 🔗 Páginas para ler em seguida
+
+| Página | Para que serve |
+|---|---|
+| [Glossário](glossario.md) | Termos do dia a dia, com âncoras para deep-link. |
+| [Quero…](quero.md) | Índice por tarefa do usuário. |
+| [Movimentos — referência](Movimentacao/Movimentos/documentacao_movimentos.md) | Mergulho na tela central da operação. |
+| [Tipos de Movimento](Movimentacao/TiposDeMovimento/documentacao_tipos_de_movimento.md) | Onde as regras dos Movimentos são configuradas. |
+| [Trilhas operacionais](Movimentacao/Trilhas/) | Caminhos prontos para as demandas mais comuns. |
+
+---
+
+**Última atualização**: Maio de 2026
+**Versão**: 1.0
+**Público-alvo**: Todos os usuários do Sol.NET — especialmente novos

--- a/visao_geral_sol_net.md
+++ b/visao_geral_sol_net.md
@@ -89,7 +89,7 @@ Mapa rápido das telas mais usadas, organizadas pela tarefa do dia:
 | Ajustar saldo manualmente | [Ajuste de Estoque](Movimentacao/documentacao_ajuste_de_estoque.md) (`79`) — gera movimento visível em `203` |
 | Saber quanto tenho de um produto | [Saldo Estoque](Movimentacao/documentacao_saldo_estoque.md) (`78`) |
 | Entender por que o saldo está assim | [Histórico de Produtos](Movimentacao/documentacao_historico_de_produtos.md) (`206`) |
-| Auditar um movimento (quem alterou, quando) | [Histórico de Movimentações](Movimentacao/documentacao_historico_de_movimentacoes.md) (`205`) |
+| Ver totais e indicadores de vendas (por dia, vendedor, portador, condição, tabela) | [Histórico de Movimentações](Movimentacao/documentacao_historico_de_movimentacoes.md) (`205`) |
 | Lançar/quitar um título | [Pagar e Receber](Financeiro/documentacao_pagar_e_receber.md) (`301`) · [Quitação](Financeiro/documentacao_quitacao.md) (`303`) |
 | Operar caixa diário | [Caixa Geral — operação](Financeiro/documentacao_caixa_geral_op.md) (`302`) |
 | Configurar como um Tipo se comporta | [Tipos de Movimento](Movimentacao/TiposDeMovimento/documentacao_tipos_de_movimento.md) (`37`) |


### PR DESCRIPTION
## Contexto

Primeira rodada de **conteúdo transversal** do portal — escopo definido no plano `~/.claude/plans/analise-o-reposit-rio-e-moonlit-rain.md`. A documentação por tela já é forte (86+ docs); o que faltava para virar "portal de conhecimento" era conteúdo que atravessa telas e dá modelo mental.

Tudo aqui é `.md` puro: sobrevive à migração para o portal Blazor descrita em `planejamento-portal-documentacao.md` e enriquece o RAG futuro. Sem busca client-side, sem plugins novos, sem "última atualização" automática — esses recursos já estão no roadmap do portal novo.

Foco em **Movimentação** por ser a maior demanda do sistema.

## O que entra

### Núcleo conceitual (raiz)

- **`glossario.md`** — ~30 termos agrupados (fiscais/SEFAZ, tributação, movimentação, estoque, verbos da operação, financeiro), com âncoras estáveis para deep-link de qualquer outro doc. Anchors com acento têm `{#id}` explícito.
- **`visao_geral_sol_net.md`** — modelo mental: eixo `Movimento ↔ Tipo ↔ Transação ↔ Estoque/Financeiro/Fiscal`, com Mermaid + link para `Assets/SolNET Mindmap.svg` (que estava sem uso no repo), 3 dimensões de qualquer operação, mapa "Quero…" e os 7 verbos.
- **`quero.md`** — índice por tarefa em primeira pessoa (~20 perguntas, ~14 de Movimentação).

### Trilhas operacionais (foco Movimentação)

Pasta nova `Movimentacao/Trilhas/`. Cada trilha é narrativa cross-tela: diagrama + passos com link para a doc completa de cada tela + \"quando dá errado\" linkando o índice de mensagens. **Não duplicam** doc de tela.

- `trilha_entrada_nfe.md` — Manifestação → Importar XML → Conferência → 201 → estoque + financeiro.
- `trilha_venda_completa.md` — 202 → ciclo Orçamento/Pedido/Venda → emissão fiscal → Quitação.
- `trilha_devolucao_venda.md` — 203 com Tipo Devolução de Venda, referência à nota original, padrão de duas etapas para NFC-e.
- `trilha_ajuste_estoque_auditoria.md` — 79 → 203 → auditoria em 206 / 78.

### Índice de mensagens

- `Movimentacao/indice_mensagens.md` — consolida as mensagens das FAQs de 201/202/203, 37, 204 e 401 em uma tabela única (mensagem · onde aparece · causa · link para a FAQ detalhada). É **índice**, não fonte primária.

### Integração

- `README.md` raiz — bloco \"Por onde começar\" acima da tabela de módulos; rodapé 4.0 → 4.1 (adição estrutural).
- `Movimentacao/README.md` — bloco \"Comece pelas trilhas\" no topo.
- `_layouts/default.html` — 3 entradas globais na sidebar (🧭 Visão geral · 📖 Glossário · ❓ Quero…) + submenu 🛤️ Trilhas operacionais em Movimentação + item Índice de mensagens.
- `llms.txt` — 9 entradas novas.

## Códigos de tela referenciados

Todos já validados na fonte canônica em sessões anteriores e registrados na memória do projeto:
`1` · `5` · `21` · `27` · `28` · `32` · `33` · `36` · `37` · `78` · `79` · `93` · `94` · `124` · `143` · `144` · `201` · `202` · `203` · `204` · `205` · `206` · `301` · `302` · `303` · `401`.

## Conformidade com CLAUDE.md

- Snake_case em todos os arquivos novos.
- Front matter Jekyll nos novos `README.md` que precisam de permalink (`Movimentacao/Trilhas/`).
- Sem termos técnicos de Delphi.
- Atalhos de teclado só `F1` (validado de uso geral); demais (`F6`–`F11`) só onde já estavam validados nas docs existentes de Movimentos.
- Telas referenciadas por nome + código F1, nunca caminho de menu.
- Mensagens de \"acesso de suporte necessário\" presentes nos lugares certos (trilhas que tocam alterações em `37`, índice de mensagens).
- Tabelas em Markdown puro; CSS do layout cuida do visual.
- Diagramas em Mermaid (`flowchart TD`).

## Test plan

- [ ] Após merge, abrir https://hetosoft.github.io/documentacao-solnet/ e verificar que o bloco \"Por onde começar\" aparece.
- [ ] Navegar pelas 3 entradas globais novas (Visão geral, Glossário, Quero…) no desktop e no drawer mobile (< 900 px); confirmar que o item ativo destaca.
- [ ] Abrir o submenu Trilhas operacionais em Movimentação; confirmar as 4 trilhas + Visão geral.
- [ ] No `glossario.md`, clicar nos 5 termos com acento no índice alfabético (Manifesto, Reforma Tributária, Transação de Estoque, Conferência, Tabela de Preço, NF-e própria) e confirmar que ancoram na seção correta.
- [ ] Em `visao_geral_sol_net.md`, conferir que o link \"Transação de Estoque\" aponta para `glossario.md#transacao-de-estoque` e abre na seção certa.
- [ ] Em cada trilha, abrir os 5–7 links para docs de tela e confirmar que respondem \"o que fazer agora\" no contexto da trilha.
- [ ] Em `indice_mensagens.md`, pegar 3 mensagens (uma de Movimentos, uma de Tipos, uma de Importar XML) e confirmar que o link aponta para a seção certa na FAQ original.
- [ ] Validar a renderização dos 5 diagramas Mermaid (5 trilhas + visão geral) na Pages — sem caracteres truncados, sem nodes faltando.
- [ ] Confirmar que `Assets/SolNET Mindmap.svg` carrega quando aberto pelo link na `visao_geral_sol_net.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)